### PR TITLE
Remove duplicate outpath for build_modules

### DIFF
--- a/lbuild/environment.py
+++ b/lbuild/environment.py
@@ -69,13 +69,13 @@ def _copytree(logger, src, dst, ignore=None):
 
 class Environment:
 
-    def __init__(self, options, modules, module, outpath, buildlog):
-        self.options = options
-        self.modules = modules
+    def __init__(self, module, buildlog):
+        self.options = module.option_value_resolver
+        self.modules = module.module_resolver
         self.__module = module
         self.__modulepath = module._filepath
         self.__repopath = module.repository._filepath
-        self.__outpath = outpath
+        self.__outpath = buildlog.outpath
 
         self.__buildlog = buildlog
         self.__template_environment = None

--- a/lbuild/main.py
+++ b/lbuild/main.py
@@ -22,7 +22,7 @@ import lbuild.module
 import lbuild.vcs.common
 from lbuild.format import format_option_short_description
 
-__version__ = '1.0.3'
+__version__ = '1.0.4'
 
 
 class InitAction:
@@ -192,7 +192,7 @@ class BuildAction(ManipulationActionBase):
 
         lbuild.environment.simulate = args.simulate
         buildlog = lbuild.buildlog.BuildLog(args.path)
-        parser.build_modules(args.path, build_modules, buildlog)
+        parser.build_modules(build_modules, buildlog)
 
         if args.simulate:
             ostream = []

--- a/lbuild/parser.py
+++ b/lbuild/parser.py
@@ -249,20 +249,16 @@ class Parser(BaseNode):
 
     @staticmethod
     def validate_modules(build_modules):
-        Parser.build_modules(None, build_modules, None)
+        Parser.build_modules(build_modules, None)
 
     @staticmethod
-    def build_modules(outpath, build_modules, buildlog):
+    def build_modules(build_modules, buildlog):
         if not len(build_modules):
             raise LbuildException("No modules selected, aborting!")
 
         groups = collections.defaultdict(list)
         for node in (build_modules + list(set(m.repository for m in build_modules))):
-            env = lbuild.environment.Environment(node.option_value_resolver,
-                                                 node.module_resolver,
-                                                 node,
-                                                 outpath,
-                                                 buildlog)
+            env = lbuild.environment.Environment(node, buildlog)
             groups[node.depth].append(Runner(node, env))
 
         exceptions = []
@@ -282,7 +278,7 @@ class Parser(BaseNode):
             raise lbuild.exception.LbuildAggregateException(exceptions)
 
         # Cannot build with these settings, just pre_build
-        if outpath is None or buildlog is None:
+        if buildlog is None:
             return
 
         for index in sorted(groups, reverse=True):

--- a/test/parser_test.py
+++ b/test/parser_test.py
@@ -182,7 +182,7 @@ class ParserTest(unittest.TestCase):
 
         outpath = tempdir.path
         log = lbuild.buildlog.BuildLog(outpath)
-        self.parser.build_modules(outpath, build_modules, log)
+        self.parser.build_modules(build_modules, log)
 
         self.assertTrue(os.path.isfile(os.path.join(outpath, "src/other.cpp")))
         self.assertTrue(os.path.isfile(os.path.join(outpath, "test/other.cpp")))
@@ -205,7 +205,7 @@ class ParserTest(unittest.TestCase):
 
         outpath = tempdir.path
         log = lbuild.buildlog.BuildLog(outpath)
-        self.parser.build_modules(outpath, build_modules, log)
+        self.parser.build_modules(build_modules, log)
 
         self.assertTrue(os.path.isfile(os.path.join(outpath, "src/module3.cpp")))
 
@@ -219,7 +219,7 @@ class ParserTest(unittest.TestCase):
         outpath = tempdir.path
         log = lbuild.buildlog.BuildLog(outpath)
         self.assertRaises(lbuild.exception.LbuildBuildException,
-                          lambda: self.parser.build_modules(outpath, build_modules, log))
+                          lambda: self.parser.build_modules(build_modules, log))
 
     @testfixtures.tempdir()
     def test_should_raise_when_overwriting_file_in_tree(self, tempdir):
@@ -229,7 +229,7 @@ class ParserTest(unittest.TestCase):
         outpath = tempdir.path
         log = lbuild.buildlog.BuildLog(outpath)
         self.assertRaises(lbuild.exception.LbuildBuildException,
-                          lambda: self.parser.build_modules(outpath, build_modules, log))
+                          lambda: self.parser.build_modules(build_modules, log))
 
     @testfixtures.tempdir()
     def test_should_raise_when_no_module_is_found(self, tempdir):

--- a/test/post_build_test.py
+++ b/test/post_build_test.py
@@ -43,7 +43,7 @@ class PostBuildTest(unittest.TestCase):
         build_modules = self.parser.resolve_dependencies(selected_modules)
 
         log = lbuild.buildlog.BuildLog(str(outpath))
-        self.parser.build_modules(outpath, build_modules, log)
+        self.parser.build_modules(build_modules, log)
         return log
 
     def setUp(self):


### PR DESCRIPTION
The outpath wasn't made abspath which lead to discrepancies in the buildlog when computing a `local_filename_out(path)`.