### PR TITLE
Add lbuild discover --values to CLI

### DIFF
--- a/lbuild/main.py
+++ b/lbuild/main.py
@@ -22,7 +22,7 @@ import lbuild.module
 import lbuild.vcs.common
 from lbuild.format import format_option_short_description
 
-__version__ = '1.0.4'
+__version__ = '1.1.0'
 
 
 class InitAction:
@@ -80,6 +80,11 @@ class DiscoverAction(ManipulationActionBase):
             action="append",
             default=[],
             help="Select a specific repository, module or option.")
+        parser.add_argument("--values",
+            dest="values",
+            action="store_true",
+            default=False,
+            help="Display option values, instead of description")
         parser.set_defaults(execute_action=self.prepare_repositories)
 
     def perform(self, args, parser, repo_options):
@@ -90,9 +95,12 @@ class DiscoverAction(ManipulationActionBase):
         if len(args.names):
             ostream = []
             for name in args.names:
-                node = parser.find(name).description
-                ostream.extend([node])
-            return "\n\n\n\n".join(ostream)
+                node = parser.find(name)
+                if args.values and node.type == node.Type.OPTION:
+                    ostream.extend(node.values)
+                else:
+                    ostream.append(node.description)
+            return "\n".join(ostream)
 
         return parser.render()
 

--- a/lbuild/option.py
+++ b/lbuild/option.py
@@ -59,6 +59,10 @@ class Option(BaseNode):
     def value(self, value):
         self._set_value(value)
 
+    @property
+    def values(self):
+        return ["String"]
+
     def is_default(self):
         return self._input == self._default
 
@@ -92,6 +96,10 @@ class BooleanOption(Option):
         Option.__init__(self, name, description, default, dependencies,
                         convert_input=self.as_boolean,
                         convert_output=self.as_boolean)
+
+    @property
+    def values(self):
+        return ["True", "False"]
 
     def format_values(self):
         if self._default:
@@ -134,9 +142,14 @@ class NumericOption(Option):
                                   numeric_value, self.fullname, self.maximum))
         self._set_value(value)
 
+    @property
+    def values(self):
+        return ["-Inf" if self.minimum is None else str(self.minimum),
+                "+Inf" if self.maximum is None else str(self.maximum)]
+
     def format_values(self):
-        minimum = c("-Inf" if self.minimum is None else str(self.minimum))
-        maximum = c("+Inf" if self.maximum is None else str(self.maximum))
+        minimum = c(self.values[0])
+        maximum = c(self.values[1])
         if self._default is None:
             return minimum + c(" ... ") + maximum
 
@@ -199,8 +212,12 @@ class EnumerationOption(Option):
             return str(obj.name)
         return str(obj).strip()
 
+    @property
+    def values(self):
+        return list(map(str, self._enumeration.keys()))
+
     def _format_values(self):
-        values = list(map(str, self._enumeration.keys()))
+        values = self.values
         values.sort(key=lambda v: (float(v) if v.isdigit() else 0, v))
         return values
 


### PR DESCRIPTION
Accidentally removed `lbuild discover-option-values` since I thought it wasn't needed, but it turns out, that modm CI requires this quite a bit.