### PR TITLE
Add simplified Builder API for using lbuild from Python

### DIFF
--- a/lbuild/api.py
+++ b/lbuild/api.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2018, Niklas Hauser
+# All Rights Reserved.
+#
+# The file is part of the lbuild project and is released under the
+# 2-clause BSD license. See the file `LICENSE.txt` for the full license
+# governing this code.
+
+import os
+
+import lbuild.environment
+from lbuild.buildlog import BuildLog
+from lbuild.parser import Parser
+from lbuild.config import ConfigNode
+from lbuild.utils import listify, listrify
+
+class Builder:
+    def __init__(self, cwd=None, config=None, options=None):
+        if cwd is None:
+            cwd = os.getcwd()
+        os.chdir(cwd)
+        self.cwd = cwd
+
+        config = ConfigNode.from_file(config, fail_silent=True)
+        file_config = ConfigNode.from_filesystem(cwd)
+        if config:
+            config.extend_last(file_config)
+        else:
+            config = file_config if file_config else ConfigNode()
+
+        self.config = config
+        self.config.add_commandline_options(listify(options))
+        self.parser = Parser(self.config)
+
+    def _load_repositories(self, repos=None):
+        self.parser.load_repositories(listrify(repos))
+        self.parser.merge_repository_options()
+
+    def _load_modules(self):
+        if not len(self.parser._undefined_repo_options()):
+            self.parser.prepare_repositories()
+            self.parser.merge_module_options()
+
+    def _filter_modules(self, modules=None):
+        self.parser.config.modules.extend(listify(modules))
+        selected_modules = self.parser.find_modules(self.parser.config.modules)
+        return self.parser.resolve_dependencies(selected_modules)
+
+
+    def load(self, repos=None):
+        self._load_repositories(repos)
+        self._load_modules()
+
+    def validate(self, modules=None):
+        build_modules = self._filter_modules(modules)
+        self.parser.validate_modules(build_modules)
+
+    def build(self, outpath, modules=None, simulate=False):
+        build_modules = self._filter_modules(modules)
+        buildlog = BuildLog(outpath)
+        lbuild.environment.simulate = simulate
+        self.parser.build_modules(build_modules, buildlog)
+        return buildlog

--- a/lbuild/buildlog.py
+++ b/lbuild/buildlog.py
@@ -98,6 +98,11 @@ class BuildLog:
 
         return operation
 
+    def _log(self, modulename, filename_in, filename_out, time=None):
+        operation = Operation(modulename, self.outpath, self.outpath, filename_in, filename_out, time)
+        with self.__lock:
+            self._operations[modulename].append(operation)
+
     def operations_per_module(self, modulename: str):
         """
         Get all operations which have been performed for the given module and

--- a/lbuild/config.py
+++ b/lbuild/config.py
@@ -118,7 +118,7 @@ class ConfigNode(anytree.AnyNode):
         filename = os.path.relpath(str(configfile), os.getcwd())
         LOGGER.debug("Parse configuration '{}'".format(filename))
         if fail_silent and not os.path.exists(filename):
-            return ConfigNode()
+            return None
 
         xmltree = ConfigNode._load_and_verify(configfile)
 

--- a/lbuild/main.py
+++ b/lbuild/main.py
@@ -210,6 +210,7 @@ class BuildAction(ManipulationActionBase):
         elif args.buildlog:
             configfilename = args.config
             logfilename = configfilename + ".log"
+            buildlog._log("lbuild", "buildlog.xml.in", logfilename)
             with open(logfilename, "wb") as logfile:
                 logfile.write(buildlog.to_xml(to_string=True, path=os.getcwd()))
 
@@ -224,12 +225,13 @@ class CleanAction(ManipulationActionBase):
             help="Remove previously generated files.")
         parser.add_argument("--buildlog",
             dest="buildlog",
+            default="project.xml.log",
             help="Use the given buildlog to identify the files to remove.")
         parser.set_defaults(execute_action=self.prepare_repositories)
 
     def perform(self, args, parser, repo_options):
         ostream = []
-        if args.buildlog is not None:
+        if os.path.exists(args.buildlog):
             with open(args.buildlog, "rb") as logfile:
                 buildlog = lbuild.buildlog.BuildLog.from_xml(logfile.read(), path=os.getcwd())
         else:

--- a/lbuild/module.py
+++ b/lbuild/module.py
@@ -35,7 +35,7 @@ class ModuleBase:
     pass
 
 
-def load_module_from_file(repository, repo_options, filename, parent=None):
+def load_module_from_file(repository, filename, parent=None):
     module = ModuleInit(repository, filename)
     if parent: module.parent = parent;
     module.functions = lbuild.node.load_functions_from_file(
@@ -48,17 +48,17 @@ def load_module_from_file(repository, repo_options, filename, parent=None):
             'ValidateException': lbuild.exception.LbuildValidateException,
         })
     module.init()
-    return module.prepare(repo_options)
+    return module.prepare()
 
 
-def load_module_from_object(repository, repo_options, module_obj, filename=None, parent=None):
+def load_module_from_object(repository, module_obj, filename=None, parent=None):
     module = ModuleInit(repository, filename)
     if parent: module.parent = parent;
     module.functions = lbuild.utils.get_global_functions(module_obj,
             required=['init', 'prepare', 'build'],
             optional=['pre_build', 'validate', 'post_build'])
     module.init()
-    return module.prepare(repo_options)
+    return module.prepare()
 
 
 def build_modules(initmodules):
@@ -116,7 +116,7 @@ class ModuleInit:
         if not self.parent.startswith(self.repository.name):
             self.parent = self.repository.name + ":" + self.parent
 
-    def prepare(self, repo_options):
+    def prepare(self):
         is_available = lbuild.utils.with_forward_exception(self,
                 lambda: self.functions["prepare"](ModulePrepareFacade(self), self.repository.option_value_resolver))
 
@@ -132,13 +132,11 @@ class ModuleInit:
         for submodule in self._submodules:
             if isinstance(submodule, ModuleBase):
                 modules = load_module_from_object(repository=self.repository,
-                                                  repo_options=repo_options,
                                                   module_obj=submodule,
                                                   filename=self.filename,
                                                   parent=self.fullname)
             else:
                 modules = load_module_from_file(repository=self.repository,
-                                                repo_options=repo_options,
                                                 filename=os.path.join(self.filepath, submodule),
                                                 parent=self.fullname)
 

--- a/lbuild/option.py
+++ b/lbuild/option.py
@@ -22,7 +22,7 @@ from .format import color_str as c
 class Option(BaseNode):
     def __init__(self, name, description, default=None, dependencies=None, convert_input=str, convert_output=str):
         BaseNode.__init__(self, name, BaseNode.Type.OPTION)
-        self._dependency_handlers = lbuild.utils.listify(dependencies)
+        self._dependency_handler = dependencies
         self._description = description
         self._in = convert_input
         self._out = convert_output
@@ -39,8 +39,8 @@ class Option(BaseNode):
 
     def _update_dependencies(self):
         self._dependencies_resolved = False
-        for handler in self._dependency_handlers:
-            self._dependency_module_names += lbuild.utils.listify(handler(self._input))
+        if self._dependency_handler:
+            self._dependency_module_names += lbuild.utils.listify(self._dependency_handler(self._input))
 
     def _set_value(self, value):
         self._input = self._in(value)

--- a/lbuild/option.py
+++ b/lbuild/option.py
@@ -30,6 +30,7 @@ class Option(BaseNode):
         self._output = None
         self._default = None
         self._set_default(default)
+        self.__hash = None
 
     def _set_default(self, default):
         if default is not None:
@@ -75,6 +76,18 @@ class Option(BaseNode):
         if self.is_default() or self._default == "":
             return c("String")
         return c("String: ") + c(str(self._default)).wrap("underlined")
+
+    def __hash__(self):
+        if self.__hash is None:
+            srepr = str(self.fullname)
+            srepr += str(self._input)
+            srepr += str(self.values)
+            srepr += str(self._description)
+            self.__hash = hash(srepr)
+        return self.__hash
+
+    def __eq__(self, other):
+        return hash(self) == hash(other)
 
     def __lt__(self, other):
         return self.fullname.__lt__(other.fullname)
@@ -251,7 +264,9 @@ class SetOption(EnumerationOption):
     def str_to_set(values):
         if isinstance(values, str):
             values = [v.strip() for v in values.split(",")]
-        return list(map(str, lbuild.utils.listify(values)))
+        else:
+            values = list(map(str, lbuild.utils.listify(values)))
+        return values
 
     def as_set(self, values):
         values = self.str_to_set(values)

--- a/lbuild/repository.py
+++ b/lbuild/repository.py
@@ -79,14 +79,14 @@ class Repository(BaseNode):
 
         return repo
 
-    def prepare(self, options):
+    def prepare(self):
         lbuild.utils.with_forward_exception(self,
                 lambda: self._functions["prepare"](RepositoryPrepareFacade(self), self.option_value_resolver))
 
         modules = []
         # Parse the modules inside this repository
         for modulefile in self._module_files:
-            module = lbuild.module.load_module_from_file(self, options, modulefile)
+            module = lbuild.module.load_module_from_file(self, modulefile)
             modules.extend(module)
 
         return modules

--- a/lbuild/utils.py
+++ b/lbuild/utils.py
@@ -84,6 +84,8 @@ def _listify(obj):
 def listify(*objs):
     return [l for o in objs for l in _listify(o)]
 
+def listrify(*objs):
+    return list(map(str, listify(*objs)))
 
 def get_global_functions(env, required, optional=None):
     """

--- a/test/dependency_test.py
+++ b/test/dependency_test.py
@@ -29,7 +29,7 @@ class DepedencyTest(unittest.TestCase):
 
     def test_should_collapse_mutiply_defined_dependencies(self):
         self.parser.parse_repository(self._get_path("multiple_dependencies/repo.lb"))
-        self.parser.prepare_repositories({})
+        self.parser.prepare_repositories()
 
         module = self.parser.find_module(":module2")
 

--- a/test/post_build_test.py
+++ b/test/post_build_test.py
@@ -35,8 +35,8 @@ class PostBuildTest(unittest.TestCase):
         configuration.add_commandline_options(cmd_options)
         self.parser._config_flat = configuration
 
-        repo_options = self.parser.merge_repository_options()
-        modules = self.parser.prepare_repositories(repo_options)
+        self.parser.merge_repository_options()
+        modules = self.parser.prepare_repositories()
 
         module_options = self.parser.merge_module_options()
         selected_modules = self.parser.find_modules(self.parser.config.modules)


### PR DESCRIPTION
`lbuild build` now logs the buildlog too and `lbuild clean` removes it.

This also makes Options hashable and compareable so they can be used as keys in dictionaries and sets, which is useful for figuring out how many different options exists.

These are internal changes, no user-facing changes (apart from the buildlog).