### PR TITLE
Use plain output if stdout is not a tty

### DIFF
--- a/lbuild/format.py
+++ b/lbuild/format.py
@@ -10,14 +10,15 @@
 
 import os
 import re
+import sys
 import shutil
 import colorful
 
 import lbuild.node
 import lbuild.filter
 
-plain = False
-WIDTH = shutil.get_terminal_size((200, 0)).columns
+plain = not sys.stdout.isatty()
+WIDTH = shutil.get_terminal_size((100, 0)).columns
 
 color_scheme = {
     "parser": None,

--- a/lbuild/main.py
+++ b/lbuild/main.py
@@ -24,7 +24,7 @@ from lbuild.format import format_option_short_description
 
 from lbuild.api import Builder
 
-__version__ = '1.4.2'
+__version__ = '1.4.3'
 
 
 class InitAction:
@@ -306,7 +306,7 @@ def prepare_argument_parser():
     argument_parser.add_argument("--plain",
         dest="plain",
         action="store_true",
-        default=False,
+        default=not sys.stdout.isatty(),
         help="Disable styled output, only output plain ASCII.")
     argument_parser.add_argument('--version',
         action='version',


### PR DESCRIPTION
In case you want to do `lbuild discover | less` for example.

cc @rleh @mhthies 