### PR TITLE
Allow attaching metadata to file operations

### DIFF
--- a/lbuild/environment.py
+++ b/lbuild/environment.py
@@ -99,7 +99,7 @@ class Environment:
     def facade_post_build(self):
         return EnvironmentPostBuildFacade(self)
 
-    def extract(self, archive_path, src=None, dest=None, ignore=None):
+    def extract(self, archive_path, src=None, dest=None, ignore=None, metadata=None):
 
         def wrap_ignore(path, files):
             ignored = lbuild.utils.ignore_patterns(*self.__module._ignore_patterns)(path, files)
@@ -157,7 +157,7 @@ class Environment:
 
             def log_copy(src, dest, operation_time):
                 self.__buildlog.log(self.__module,
-                                    os.path.join(archive_path, src), dest, operation_time)
+                                    os.path.join(archive_path, src), dest, operation_time, metadata)
 
             if fn_isdir(src):
                 _copytree(log_copy, src, destpath, wrap_ignore,
@@ -171,7 +171,7 @@ class Environment:
                 total = endtime - starttime
                 log_copy(src, destpath, total)
 
-    def copy(self, src, dest=None, ignore=None):
+    def copy(self, src, dest=None, ignore=None, metadata=None):
         """
         Copy file or directory from the modulepath to the buildpath.
 
@@ -203,7 +203,7 @@ class Environment:
                                   "'{}'".format(srcrelpath))
 
         def log_copy(src, dest, operation_time):
-            self.__buildlog.log(self.__module, src, dest, operation_time)
+            self.__buildlog.log(self.__module, src, dest, operation_time, metadata)
 
         if os.path.isdir(srcpath):
             _copytree(log_copy,
@@ -260,7 +260,7 @@ class Environment:
             self.__reload_template_environment({})
         return self.__template_environment
 
-    def template(self, src, dest=None, substitutions=None, filters=None):
+    def template(self, src, dest=None, substitutions=None, filters=None, metadata=None):
         """
         Uses the Jinja2 template engine to generate files.
 
@@ -332,7 +332,7 @@ class Environment:
 
         endtime = time.time()
         total = endtime - starttime
-        self.__buildlog.log(self.__module, self.modulepath(src), outfile_name, total)
+        self.__buildlog.log(self.__module, self.modulepath(src), outfile_name, total, metadata)
 
     def modulepath(self, *path):
         """Relocate given path to the path of the module file."""

--- a/lbuild/facade.py
+++ b/lbuild/facade.py
@@ -178,14 +178,14 @@ class EnvironmentPostBuildFacade(EnvironmentValidateFacade):
     def substitutions(self, substitutions):
         self._env.substitutions = substitutions
 
-    def copy(self, src, dest=None, ignore=None):
-        self._env.copy(src, dest, ignore)
+    def copy(self, src, dest=None, ignore=None, metadata=None):
+        self._env.copy(src, dest, ignore, metadata)
 
-    def extract(self, archive, src=None, dest=None, ignore=None):
-        self._env.extract(archive, src, dest, ignore)
+    def extract(self, archive, src=None, dest=None, ignore=None, metadata=None):
+        self._env.extract(archive, src, dest, ignore, metadata)
 
-    def template(self, src, dest=None, substitutions=None, filters=None):
-        self._env.template(src, dest, substitutions, filters)
+    def template(self, src, dest=None, substitutions=None, filters=None, metadata=None):
+        self._env.template(src, dest, substitutions, filters, metadata)
 
     def generated_local_files(self, filterfunc=None):
         return self._env.generated_local_files(filterfunc)
@@ -253,6 +253,7 @@ class BuildLogFacade:
         self.__metadata = buildlog.metadata
         self.__repo_metadata = buildlog.repo_metadata
         self.__module_metadata = buildlog.module_metadata
+        self.__operation_metadata = buildlog.operation_metadata
 
     @property
     def outpath(self):
@@ -261,6 +262,10 @@ class BuildLogFacade:
     @property
     def metadata(self):
         return self.__metadata
+
+    @property
+    def operation_metadata(self):
+        return self.__operation_metadata
 
     @property
     def module_metadata(self):

--- a/lbuild/main.py
+++ b/lbuild/main.py
@@ -21,7 +21,7 @@ from lbuild.format import format_option_short_description
 
 from lbuild.api import Builder
 
-__version__ = '1.5.6'
+__version__ = '1.6.0'
 
 
 class InitAction:


### PR DESCRIPTION
This allows to attach metadata to file operations and provides this as to the post-build step (key, filename, data) api in the buildlog.
See https://github.com/modm-io/modm/issues/125 for context.

cc @dergraaf 