### PR TITLE
Constrain requirement versions

### DIFF
--- a/lbuild/format.py
+++ b/lbuild/format.py
@@ -65,9 +65,7 @@ class ColorWrapper:
     def wrap(self, name):
         style = ansi_escape(name)
         if style is not None:
-            if name in ["underlined", "bold"]:
-                if name == "underlined":
-                    name = "underline"
+            if name in ["underline", "bold"]:
                 close = ansi_escape("no_" + name)
             else:
                 close = ansi_escape("close_fg_color")
@@ -145,7 +143,7 @@ _cw = ColorWrapper
 def format_option_name(node, fullname=True):
     line = _cw(node.fullname if fullname else node.name).wrap(node).wrap("bold")
     if not node.is_default():
-        line.wrap("underlined")
+        line.wrap("underline")
     return line
 
 

--- a/lbuild/main.py
+++ b/lbuild/main.py
@@ -21,7 +21,7 @@ from lbuild.format import format_option_short_description
 
 from lbuild.api import Builder
 
-__version__ = '1.5.0'
+__version__ = '1.5.1'
 
 
 class InitAction:

--- a/lbuild/main.py
+++ b/lbuild/main.py
@@ -21,7 +21,7 @@ from lbuild.format import format_option_short_description
 
 from lbuild.api import Builder
 
-__version__ = '1.5.1'
+__version__ = '1.5.2'
 
 
 class InitAction:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,11 +1,11 @@
 lxml
 jinja2
-anytree
-colorful
+anytree>=2.4.3
+colorful<0.4.4
 
 # Required for the tests
 testfixtures
 coverage
 
 # For the handling of external repositories
-gitpython
+gitpython>=2.1.11

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 lxml
 jinja2
 anytree>=2.4.3
-colorful<0.4.4
+colorful==0.4.4
 
 # Required for the tests
 testfixtures


### PR DESCRIPTION
The fix for https://github.com/timofurrer/colorful/issues/11 in colorful is not backwards compatible.
This contrains the version on packages that are maintained by only a few people.

cc @rleh 