### PR TITLE
Make children unavailable if any of their parents is unavailable

### DIFF
--- a/lbuild/main.py
+++ b/lbuild/main.py
@@ -21,7 +21,7 @@ from lbuild.format import format_option_short_description
 
 from lbuild.api import Builder
 
-__version__ = '1.6.0'
+__version__ = '1.6.1'
 
 
 class InitAction:

--- a/test/buildlog_test.py
+++ b/test/buildlog_test.py
@@ -32,11 +32,11 @@ class BuildLogTest(unittest.TestCase):
         module1a = lbuild.module.ModuleInit(self.repo, "/m1/a/module.lb")
         module1a.name = "module1a"
         module1a.parent = "repo:module1"
-        module1.available = True
+        module1a.available = True
 
         module2 = lbuild.module.ModuleInit(self.repo, "/m2/module.lb")
         module2.name = "module2"
-        module1.available = True
+        module2.available = True
 
         self.module1, self.module1a, self.module2 = \
             lbuild.module.build_modules([module1, module1a, module2])

--- a/test/parser_test.py
+++ b/test/parser_test.py
@@ -75,6 +75,26 @@ class ParserTest(unittest.TestCase):
         self.assertIn("repo2:module4:submodule1", repo.modules)
         self.assertIn("repo2:module4:submodule2", repo.modules)
 
+    def test_should_ignore_children_of_disabled_parents(self):
+        repo = self.parser.parse_repository(self._get_path("unavailable_parent/repo.lb"))
+        self.assertEqual(1, len(self.parser.repositories))
+        self.parser.merge_repository_options()
+        self.parser.prepare_repositories()
+
+        self.assertEqual(2, len(repo.modules))
+        # parent_a is unavailable, so should all children
+        self.assertNotIn("unavailable_parent:parent_a", repo.modules)
+        self.assertNotIn("unavailable_parent:child_a", repo.modules)
+        self.assertNotIn("unavailable_parent:subchild_a", repo.modules)
+
+        # parent_b is available, so is child_b2
+        self.assertIn("unavailable_parent:parent_b", repo.modules)
+        self.assertIn("unavailable_parent:parent_b:child_b2", repo.modules)
+        # However, child_b is unavailable and so should its children
+        self.assertNotIn("unavailable_parent:child_b", repo.modules)
+        self.assertNotIn("unavailable_parent:subchild_b", repo.modules)
+        self.assertNotIn("unavailable_parent:subsubchild_b", repo.modules)
+
     def test_repository_should_contain_options(self):
         repo = self.parser.parse_repository(self._get_path("repository_options/repo.lb"))
         options = self.parser.repo_options

--- a/test/resources/parser/unavailable_parent/child_a.lb
+++ b/test/resources/parser/unavailable_parent/child_a.lb
@@ -1,0 +1,10 @@
+
+def init(module):
+	module.parent = ":parent_a"
+	module.name = "child_a"
+
+def prepare(module, options):
+	return True
+
+def build(env):
+	pass

--- a/test/resources/parser/unavailable_parent/child_b.lb
+++ b/test/resources/parser/unavailable_parent/child_b.lb
@@ -1,0 +1,10 @@
+
+def init(module):
+	module.parent = ":parent_b"
+	module.name = "child_b"
+
+def prepare(module, options):
+	return False
+
+def build(env):
+	pass

--- a/test/resources/parser/unavailable_parent/child_b2.lb
+++ b/test/resources/parser/unavailable_parent/child_b2.lb
@@ -1,0 +1,10 @@
+
+def init(module):
+	module.parent = ":parent_b"
+	module.name = "child_b2"
+
+def prepare(module, options):
+	return True
+
+def build(env):
+	pass

--- a/test/resources/parser/unavailable_parent/parent_a.lb
+++ b/test/resources/parser/unavailable_parent/parent_a.lb
@@ -1,0 +1,9 @@
+
+def init(module):
+	module.name = "parent_a"
+
+def prepare(module, options):
+	return False
+
+def build(env):
+	pass

--- a/test/resources/parser/unavailable_parent/parent_b.lb
+++ b/test/resources/parser/unavailable_parent/parent_b.lb
@@ -1,0 +1,9 @@
+
+def init(module):
+	module.name = "parent_b"
+
+def prepare(module, options):
+	return True
+
+def build(env):
+	pass

--- a/test/resources/parser/unavailable_parent/repo.lb
+++ b/test/resources/parser/unavailable_parent/repo.lb
@@ -1,0 +1,6 @@
+
+def init(repo):
+    repo.name = "unavailable_parent"
+
+def prepare(repo, options):
+    repo.find_modules_recursive(".", modulefile="*.lb", ignore="repo.lb")

--- a/test/resources/parser/unavailable_parent/subchild_a.lb
+++ b/test/resources/parser/unavailable_parent/subchild_a.lb
@@ -1,0 +1,10 @@
+
+def init(module):
+	module.parent = ":parent_a:child_a"
+	module.name = "subchild_a"
+
+def prepare(module, options):
+	return True
+
+def build(env):
+	pass

--- a/test/resources/parser/unavailable_parent/subchild_b.lb
+++ b/test/resources/parser/unavailable_parent/subchild_b.lb
@@ -1,0 +1,10 @@
+
+def init(module):
+	module.parent = ":parent_b:child_b"
+	module.name = "subchild_b"
+
+def prepare(module, options):
+	return True
+
+def build(env):
+	pass

--- a/test/resources/parser/unavailable_parent/subsubchild_b.lb
+++ b/test/resources/parser/unavailable_parent/subsubchild_b.lb
@@ -1,0 +1,10 @@
+
+def init(module):
+	module.parent = ":parent_b:child_b:subchild_b"
+	module.name = "subsubchild_b"
+
+def prepare(module, options):
+	return True
+
+def build(env):
+	pass


### PR DESCRIPTION
This fixes a bug where available children would fail to search for their parent, which is unavailable.
This fix allows to disable entire subtrees, by making that subtree parent unavailable, saving a lot of duplicated checking for the same conditions for every single child.