### PR TITLE
Fixes a bug in GitPython not checking out submodules correctly

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,9 @@ Projects using *lbuild*:
 
 - [modm generates a HAL for hundreds of embedded devices][modm] using *lbuild*
   and a data-driven code generation pipeline.
+- [OUTPOST - Open modUlar sofTware PlatfOrm for SpacecrafT][outpost] uses *lbuild*
+  to assemble an execution platform targeted at embedded systems running mission
+  critical software.
 
 The dedicated maintainer of *lbuild* is [@salkinium][salkinium].
 
@@ -763,6 +766,7 @@ it is therefore recommended to:
 
 
 [modm]: https://modm.io/how-modm-works
+[outpost]: https://github.com/DLR-RY/outpost-core
 [jinja2]: http://jinja.pocoo.org
 [python]: https://www.python.org
 [pypi]: https://pypi.org/project/lbuild

--- a/lbuild/main.py
+++ b/lbuild/main.py
@@ -21,7 +21,7 @@ from lbuild.format import format_option_short_description
 
 from lbuild.api import Builder
 
-__version__ = '1.6.1'
+__version__ = '1.6.2'
 
 
 class InitAction:

--- a/lbuild/vcs/git.py
+++ b/lbuild/vcs/git.py
@@ -47,18 +47,15 @@ class Repository:
             self.switch_to_commit(repo, self.commit)
         else:
             self.switch_to_branch(repo, self.branch)
-
-        for submodule in repo.submodules:
-            submodule.update(init=True, recursive=True)
+        repo.git.submodule('update', '--init', '--recursive')
 
     def update(self):
         repo = self.get_repository()
         LOGGER.debug("Pull from origin")
         origin = repo.remotes.origin
         origin.pull()
-
-        for submodule in repo.submodules:
-            submodule.update(recursive=True)
+        repo.git.submodule('sync')
+        repo.git.submodule('update', '--recursive')
 
     @staticmethod
     def switch_to_commit(repo, commit):


### PR DESCRIPTION
Issue first [discovered here](https://circleci.com/gh/modm-io/Invensense-eMD/6):
```
$ lbuild init
[WARNING] git.objects.submodule.base: Failed to checkout tracking branch refs/heads/master
```
The code does the same, but more directly via the Git API, not the Python API of GitPython.
cc @dergraaf can you check if this will cause any issues on your end?