### PR TITLE
Make repo.add_modules() add modules in software

### DIFF
--- a/lbuild/facade.py
+++ b/lbuild/facade.py
@@ -87,6 +87,9 @@ class RepositoryPrepareFacade(BaseNodePrepareFacade):
     def add_modules(self, *modules):
         self._node.add_modules(*modules)
 
+    def add_submodule(self, module):
+        self._node.add_modules(module)
+
     def glob(self, pattern):
         return self._node.glob(pattern)
 
@@ -106,6 +109,9 @@ class ModulePrepareFacade(BaseNodePrepareFacade):
 
     def add_option(self, option):
         self._node._options.append(option)
+
+    def add_modules(self, *modules):
+        self._node._submodules.extend(modules)
 
     def add_submodule(self, module):
         self._node._submodules.append(module)

--- a/lbuild/main.py
+++ b/lbuild/main.py
@@ -21,7 +21,7 @@ from lbuild.format import format_option_short_description
 
 from lbuild.api import Builder
 
-__version__ = '1.6.2'
+__version__ = '1.6.3'
 
 
 class InitAction:

--- a/lbuild/module.py
+++ b/lbuild/module.py
@@ -35,11 +35,7 @@ def load_module_from_file(repository, filename, parent=None):
         filename,
         required=['init', 'prepare', 'build'],
         optional=['pre_build', 'validate', 'post_build'],
-        local={
-            'Module': ModuleBase,
-            'PreBuildException': lbuild.exception.LbuildValidateException,
-            'ValidateException': lbuild.exception.LbuildValidateException,
-        })
+        local={'PreBuildException': lbuild.exception.LbuildValidateException})
 
     module.init()
     return module.prepare()

--- a/lbuild/node.py
+++ b/lbuild/node.py
@@ -18,7 +18,7 @@ import anytree
 import lbuild.filter
 import lbuild.format
 
-from .exception import LbuildException
+from .exception import LbuildException, LbuildValidateException
 
 LOGGER = logging.getLogger('lbuild.node')
 
@@ -37,6 +37,8 @@ def load_functions_from_file(repository, filename: str, required, optional=None,
             'repopath': RelocatePath(repository._filepath),
             'FileReader': LocalFileReaderFactory(localpath),
             'listify': lbuild.filter.listify,
+            'ValidateException': LbuildValidateException,
+            'Module': lbuild.module.ModuleBase,
             # 'ignore_patterns': shutil.ignore_patterns,
 
             'StringOption': lbuild.option.StringOption,


### PR DESCRIPTION
This isn't really a new feature, this should have worked from the beginning, I just never needed this until now.

I've added `add_submodule(module)` and `add_modules(*modules)` to both module and repo facades to make them have the same functionality.