### PR TITLE
Only parse all repositories files once

### DIFF
--- a/lbuild/main.py
+++ b/lbuild/main.py
@@ -21,7 +21,7 @@ from lbuild.format import format_option_short_description
 
 from lbuild.api import Builder
 
-__version__ = '1.6.3'
+__version__ = '1.6.4'
 
 
 class InitAction:

--- a/lbuild/parser.py
+++ b/lbuild/parser.py
@@ -9,6 +9,7 @@
 # governing this code.
 
 import sys
+import os.path
 import random
 import logging
 import collections
@@ -75,7 +76,7 @@ class Parser(BaseNode):
         return {o.fullname:o for o in self.all_options() if o.depth > 2}
 
     def load_repositories(self, repofilenames=None):
-        repofiles = set(utils.listify(repofilenames))
+        repofiles = set(os.path.realpath(p) for p in utils.listify(repofilenames))
         parsed = set()
         config_map = {}
 


### PR DESCRIPTION
This normalizes all repository paths passed by command line arguments so
that they are only parsed once.