### PR TITLE
Share data and code with module queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ Or check out specific module and option descriptions:
 This parent module defines a common set of functionality that is independent of
 the specific build system generator implementation.
 
->>>> modm:build:project.name
+>>>> modm:build:project.name  [StringOption]
 
 # Project Name
 
@@ -214,7 +214,7 @@ The project name defaults to the folder name you're calling lbuild from.
 Value: parent-folder
 Inputs: [String]
 
->>>> modm:build:build.path
+>>>> modm:build:build.path  [StringOption]
 
 # Build Path
 

--- a/lbuild/__init__.py
+++ b/lbuild/__init__.py
@@ -16,6 +16,7 @@ from . import environment
 from . import exception
 from . import module
 from . import option
+from . import query
 from . import parser
 from . import repository
 from . import utils
@@ -29,6 +30,7 @@ __all__ = [
     'facade',
     'module',
     'node',
+    'query',
     'option',
     'parser',
     'repository',

--- a/lbuild/environment.py
+++ b/lbuild/environment.py
@@ -69,6 +69,7 @@ class Environment:
 
     def __init__(self, module, buildlog):
         self.options = module.option_value_resolver
+        self.queries = module.query_resolver(self.facade_validate)
         self.modules = module.module_resolver
         self.__module = module
         self.__modulepath = module._filepath
@@ -386,41 +387,6 @@ class Environment:
         post-build step to generate additional files/data.
         """
         self.__buildlog.add_metadata(self.__module, key, values)
-
-    def has_option(self, key):
-        """Query whether an option exists."""
-        try:
-            _ = self.options[key]
-            return True
-        except LbuildException:
-            return False
-
-    def has_module(self, key):
-        """Query whether a module exists."""
-        try:
-            _ = self.modules[key]
-            return True
-        except LbuildException:
-            return False
-
-    def get_option(self, key, default=None):
-        """
-        Get an option value.
-
-        Returns a user configurable default value if the option is not found.
-        """
-        try:
-            return self.options[key]
-        except LbuildException:
-            return default
-
-    def __getitem__(self, key):
-        """
-        Get an option value.
-
-        Raises an exception if the option is not found.
-        """
-        return self.options[key]
 
     def __repr__(self):
         return repr(self.options)

--- a/lbuild/facade.py
+++ b/lbuild/facade.py
@@ -64,7 +64,7 @@ class RepositoryInitFacade(BaseNodeInitFacade):
         BaseNodeInitFacade.__init__(self, repository)
 
     def add_option(self, option):
-        self._node.add_option(option)
+        self._node.add_child(option)
 
     def add_ignore_patterns(self, *patterns):
         self._node._ignore_patterns.extend(patterns)
@@ -110,6 +110,9 @@ class ModulePrepareFacade(BaseNodePrepareFacade):
     def add_option(self, option):
         self._node._options.append(option)
 
+    def add_query(self, query):
+        self._node._queries.append(query)
+
     def add_modules(self, *modules):
         self._node._submodules.extend(modules)
 
@@ -147,16 +150,22 @@ class EnvironmentValidateFacade:
         return self._env.log
 
     def has_option(self, key):
-        return self._env.has_option(key)
+        return key in self._env.options
 
     def has_module(self, key):
-        return self._env.has_module(key)
+        return key in self._env.modules
+
+    def has_query(self, key):
+        return key in self._env.queries
 
     def get(self, key, default=None):
-        return self._env.get_option(key, default)
+        return self._env.options.get(key, default)
+
+    def query(self, key, default=None):
+        return self._env.queries.get(key, default)
 
     def __getitem__(self, key):
-        return self._env.__getitem__(key)
+        return self._env.options[key]
 
     # deprecated
     def get_option(self, key, default=None):

--- a/lbuild/format.py
+++ b/lbuild/format.py
@@ -190,9 +190,12 @@ def format_option_short_description(node):
 
 
 def format_description(node, description):
-    output = [_cw(">> ") + _cw(node.description_name).wrap(node).wrap("bold"), _cw("")]
+    type_description = "  [{}]".format(node.__class__.__name__)
+    output = [_cw(">> ") + _cw(node.description_name).wrap(node).wrap("bold") + _cw(type_description)]
     if description:
-        output += [_cw(description.strip(" \n"))]
+        description = description.strip()
+        if len(description):
+            output += [_cw(""), _cw(description)]
 
     if node.type == node.Type.OPTION:
         value = format_option_value(node, single_line=False)[0]

--- a/lbuild/main.py
+++ b/lbuild/main.py
@@ -93,10 +93,18 @@ class DiscoverAction(ManipulationActionBase):
             action="store_true",
             default=False,
             help="Display option values, instead of description")
+        parser.add_argument(
+            "--developer",
+            action="store_true",
+            default=False,
+            dest="show_developer_view",
+            help="Show module queries in tree view and descriptions.")
         parser.set_defaults(execute_action=self.load_repositories)
 
     @staticmethod
     def perform(args, builder):
+        if args.show_developer_view:
+            lbuild.format.SHOW_NODES.update(lbuild.node.BaseNode.Type)
         if args.names:
             ostream = []
             for node in builder.parser.find_all(args.names):

--- a/lbuild/main.py
+++ b/lbuild/main.py
@@ -21,7 +21,7 @@ from lbuild.format import format_option_short_description
 
 from lbuild.api import Builder
 
-__version__ = '1.6.5'
+__version__ = '1.7.0'
 
 
 class InitAction:

--- a/lbuild/module.py
+++ b/lbuild/module.py
@@ -107,6 +107,7 @@ class ModuleInit:
         self._options = []
         self._dependencies = []
         self._filters = {}
+        self._queries = []
 
     @property
     def fullname(self):
@@ -176,10 +177,8 @@ class Module(BaseNode):
         self._filters.update({"{}.{}".format(self._repository.name, name): func
                               for name, func in module._filters.items()})
 
-        # OptionNameResolver defined in the module configuration file. These
-        # options are configurable through the project configuration file.
-        for option in module._options:
-            self.add_option(option)
+        for child in (module._options + module._queries):
+            self.add_child(child)
 
         self.add_dependencies(*module._dependencies)
         if ":" in module.parent:

--- a/lbuild/option.py
+++ b/lbuild/option.py
@@ -32,7 +32,6 @@ class Option(BaseNode):
         self._output = None
         self._default = None
         self._set_default(default)
-        self.__hash = None
 
     def _set_default(self, default):
         if default is not None:
@@ -71,7 +70,7 @@ class Option(BaseNode):
         return self._input == self._default
 
     def format_value(self):
-        value = str(self._input).strip(" \n")
+        value = str(self._input).strip()
         if value == "":
             value = '""'
         return value
@@ -80,27 +79,6 @@ class Option(BaseNode):
         if self.is_default() or self._default == "":
             return _cw("String")
         return _cw("String: ") + _cw(str(self._default)).wrap("underlined")
-
-    def __hash__(self):
-        if self.__hash is None:
-            srepr = str(self.fullname)
-            srepr += str(self._input)
-            srepr += str(self.values)
-            srepr += str(self._description)
-            self.__hash = hash(srepr)
-        return self.__hash
-
-    def __eq__(self, other):
-        return hash(self) == hash(other)
-
-    def __lt__(self, other):
-        return self.fullname.__lt__(other.fullname)
-
-    def __str__(self):
-        return self.fullname
-
-    def __repr__(self):
-        return "{}({})".format(self.__class__.__name__, self.fullname)
 
 
 class StringOption(Option):

--- a/lbuild/query.py
+++ b/lbuild/query.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+#
+# Copyright (c) 2019, Niklas Hauser
+# All Rights Reserved.
+#
+# The file is part of the lbuild project and is released under the
+# 2-clause BSD license. See the file `LICENSE.txt` for the full license
+# governing this code.
+
+import inspect
+import textwrap
+
+from .exception import LbuildException
+from .node import BaseNode
+
+
+class Query(BaseNode):
+
+    def __init__(self, function, name=None):
+        if not callable(function):
+            raise LbuildException("Query '{}' ({}) must be callable!"
+                                  .format(function, type(function).__name__))
+        fname = function.__name__
+        if name is None:
+            if "<lambda>" in fname:
+                raise LbuildException("Query '{}' ({}) must have a name!"
+                                      .format(function, type(function).__name__))
+            name = fname
+
+        BaseNode.__init__(self, name, BaseNode.Type.QUERY)
+
+        fdoc = function.__doc__
+        self._description = textwrap.dedent("" if fdoc is None else fdoc).strip()
+        self.suffix = str(inspect.signature(function))
+        self._function = function
+
+    @property
+    def module(self):
+        return self.parent
+
+    @property
+    def description_name(self):
+        return self.fullname + self.suffix
+
+    def value(self, env):
+        return self._function
+
+
+class EnvironmentQuery(Query):
+
+    def __init__(self, factory, name=None):
+        Query.__init__(self, name=name, function=factory)
+        if len(inspect.signature(factory).parameters.keys()) != 1:
+            raise LbuildException("EnvironmentQuery '{}' must take 'env' as argument!"
+                                  .format(factory))
+        self.suffix = ""
+        self.__result = None
+        self.__called = False
+
+    def value(self, env):
+        if not self.__called:
+            self.__result = self._function(env)
+            self.__called = True
+        return self.__result

--- a/setup.py
+++ b/setup.py
@@ -60,7 +60,6 @@ setup(
         "Programming Language :: Python",
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3.5",
-        "Programming Language :: Python :: 3.6",
         "Topic :: Software Development",
         "Topic :: Software Development :: Code Generators",
         "Topic :: Software Development :: Embedded Systems",

--- a/test/module_test.py
+++ b/test/module_test.py
@@ -31,13 +31,13 @@ class ModuleTest(unittest.TestCase):
         module.available = True
         self.module, = lbuild.module.build_modules([module])
 
-        self.repo.add_option(Option("target", "", default="hosted"))
-        self.repo.add_option(NumericOption("foo", "", default=43))
+        self.repo.add_child(Option("target", "", default="hosted"))
+        self.repo.add_child(NumericOption("foo", "", default=43))
 
-        self.module.add_option(NumericOption("foo", "", default=456))
-        self.module.add_option(NumericOption("bar", "", default=768))
-        self.module.add_option(BooleanOption("xyz", "", default="Yes"))
-        self.module.add_option(Option("abc", "", default="Hello World!"))
+        self.module.add_child(NumericOption("foo", "", default=456))
+        self.module.add_child(NumericOption("bar", "", default=768))
+        self.module.add_child(BooleanOption("xyz", "", default="Yes"))
+        self.module.add_child(Option("abc", "", default="Hello World!"))
 
     def test_resolver_should_reject_invalid_names(self):
         resolver = self.module.module_resolver

--- a/test/option_test.py
+++ b/test/option_test.py
@@ -43,7 +43,7 @@ class OptionTest(unittest.TestCase):
 
     def test_should_provide_string_representation_for_base_option_with_repo(self):
         option = lbuild.option.Option("test", "description", "value")
-        self.repo.add_option(option)
+        self.repo.add_child(option)
 
         output = option.description
         self.assertTrue(output.startswith(">> repo:test"))
@@ -51,7 +51,7 @@ class OptionTest(unittest.TestCase):
 
     def test_should_provide_string_representation_for_base_option_full(self):
         option = lbuild.option.Option("test", "description", "value")
-        self.module.add_option(option)
+        self.module.add_child(option)
 
         output = option.description
         self.assertTrue(output.startswith(">> repo:module:test"))

--- a/test/option_test.py
+++ b/test/option_test.py
@@ -38,7 +38,7 @@ class OptionTest(unittest.TestCase):
         option = lbuild.option.Option("test", "description", "value")
 
         output = option.description
-        self.assertTrue(output.startswith(">> test"))
+        self.assertTrue(output.startswith(">> test  [Option]"))
         self.assertTrue("value" in output)
 
     def test_should_provide_string_representation_for_base_option_with_repo(self):
@@ -46,7 +46,7 @@ class OptionTest(unittest.TestCase):
         self.repo.add_child(option)
 
         output = option.description
-        self.assertTrue(output.startswith(">> repo:test"))
+        self.assertTrue(output.startswith(">> repo:test  [Option]"))
         self.assertTrue("value" in output)
 
     def test_should_provide_string_representation_for_base_option_full(self):
@@ -54,7 +54,7 @@ class OptionTest(unittest.TestCase):
         self.module.add_child(option)
 
         output = option.description
-        self.assertTrue(output.startswith(">> repo:module:test"))
+        self.assertTrue(output.startswith(">> repo:module:test  [Option]"))
         self.assertTrue("value" in output)
 
     def test_should_provide_short_description(self):
@@ -65,7 +65,7 @@ class OptionTest(unittest.TestCase):
         option = lbuild.option.Option("test", "long description", "value")
         output = option.description
 
-        self.assertIn("test", output, "Option name")
+        self.assertIn("test  [Option]", output)
         self.assertIn("Value: value", output)
         self.assertIn("Inputs: [String]", output)
         self.assertIn("long description", output)
@@ -74,7 +74,7 @@ class OptionTest(unittest.TestCase):
         option = lbuild.option.Option("test", "long description")
         output = option.description
 
-        self.assertIn("test", output, "Option name")
+        self.assertIn("test  [Option]", output)
         self.assertIn("Value: REQUIRED", output)
         self.assertIn("Inputs: [String]", output)
         self.assertIn("long description", output)
@@ -83,6 +83,7 @@ class OptionTest(unittest.TestCase):
         option = lbuild.option.BooleanOption("test",
                                              "description",
                                              False)
+        self.assertIn("test  [BooleanOption]", option.description)
         self.assertEqual(False, option.value)
         option.value = 1
         self.assertEqual(True, option.value)
@@ -101,6 +102,7 @@ class OptionTest(unittest.TestCase):
                                              minimum=0,
                                              maximum=100,
                                              default=1)
+        self.assertIn("test  [NumericOption]", option.description)
         self.assertEqual(1, option.value)
         option.value = 2
         self.assertEqual(2, option.value)
@@ -140,6 +142,7 @@ class OptionTest(unittest.TestCase):
                                                  "description",
                                                  default=TestEnum.value1,
                                                  enumeration=TestEnum)
+        self.assertIn("test  [EnumerationOption]", option.description)
         self.assertEqual(1, option.value)
 
     def test_should_be_constructable_from_enum_set(self):
@@ -152,6 +155,7 @@ class OptionTest(unittest.TestCase):
                                          "description",
                                          default=[TestEnum.value1, TestEnum.value2],
                                          enumeration=TestEnum)
+        self.assertIn("test  [SetOption]", option.description)
         self.assertEqual([1, 2], option.value)
 
     def test_should_be_constructable_from_dict(self):

--- a/test/query_test.py
+++ b/test/query_test.py
@@ -103,7 +103,7 @@ class QueryTest(unittest.TestCase):
 
         query = lbuild.query.EnvironmentQuery(factory=self.method)
         self.assertEqual("method", query.name)
-        self.assertTrue(query.description.startswith(">> method"))
+        self.assertTrue(query.description.startswith(">> method  [EnvironmentQuery]"))
         self.assertIn("method docstring", query.description)
 
     def test_should_call_function(self):

--- a/test/query_test.py
+++ b/test/query_test.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2019, Niklas Hauser
+# All Rights Reserved.
+#
+# The file is part of the lbuild project and is released under the
+# 2-clause BSD license. See the file `LICENSE.txt` for the full license
+# governing this code.
+
+import os
+import sys
+import enum
+import unittest
+
+# Hack to support the usage of `coverage`
+sys.path.append(os.path.abspath("."))
+
+import lbuild.query
+from lbuild.repository import Repository
+
+
+class QueryTest(unittest.TestCase):
+
+    def setUp(self):
+        self.repo = Repository("path", name="repo")
+        module = lbuild.module.ModuleInit(self.repo, "filename")
+        module.name = "module"
+        module.available = True
+        self.module = lbuild.module.build_modules([module])[0]
+        self.env = "environment"
+
+        # Disable advanced formatting for a console and use the plain output
+        lbuild.format.PLAIN = True
+
+    def method(self, arg):
+        """
+        method docstring
+        """
+        return arg
+
+    def test_should_construct_function(self):
+        def local_function():
+            """
+            local docstring
+            """
+            pass
+
+        with self.assertRaises(lbuild.exception.LbuildException):
+            query = lbuild.query.Query(function=int())
+        with self.assertRaises(lbuild.exception.LbuildException):
+            query = lbuild.query.Query(function=2)
+        with self.assertRaises(lbuild.exception.LbuildException):
+            query = lbuild.query.Query(function=lambda: None)
+        with self.assertRaises(lbuild.exception.LbuildException):
+            query = lbuild.query.Query(function=lambda arg: arg)
+
+        query = lbuild.query.Query(function=local_function)
+        self.assertEqual("local_function", query.name)
+        self.assertTrue(query.description.startswith(">> local_function()"))
+        self.assertIn("local docstring", query.description)
+
+        query = lbuild.query.Query(name="different", function=local_function)
+        self.assertEqual("different", query.name)
+        self.assertTrue(query.description.startswith(">> different()"))
+        self.assertIn("local docstring", query.description)
+
+        query = lbuild.query.Query(function=self.method)
+        self.assertEqual("method", query.name)
+        self.assertTrue(query.description.startswith(">> method(arg)"))
+        self.assertIn("method docstring", query.description)
+
+        query = lbuild.query.Query(name="different", function=self.method)
+        self.assertEqual("different", query.name)
+        self.assertTrue(query.description.startswith(">> different(arg)"))
+        self.assertIn("method docstring", query.description)
+
+        query = lbuild.query.Query(name="lambda_name", function=lambda: None)
+        self.assertEqual("lambda_name", query.name)
+        self.assertTrue(query.description.startswith(">> lambda_name()"))
+
+        query = lbuild.query.Query(name="lambda_name", function=lambda arg, arg2: None)
+        self.assertEqual("lambda_name", query.name)
+        self.assertTrue(query.description.startswith(">> lambda_name(arg, arg2)"))
+
+    def test_should_construct_property(self):
+        def local_factory():
+            """
+            local docstring
+            """
+            pass
+
+        with self.assertRaises(lbuild.exception.LbuildException):
+            query = lbuild.query.EnvironmentQuery(factory=int())
+        with self.assertRaises(lbuild.exception.LbuildException):
+            query = lbuild.query.EnvironmentQuery(factory=2)
+        with self.assertRaises(lbuild.exception.LbuildException):
+            query = lbuild.query.EnvironmentQuery(factory=lambda: None)
+        with self.assertRaises(lbuild.exception.LbuildException):
+            query = lbuild.query.EnvironmentQuery(factory=lambda arg: arg)
+        with self.assertRaises(lbuild.exception.LbuildException):
+            query = lbuild.query.EnvironmentQuery(factory=local_factory)
+
+        query = lbuild.query.EnvironmentQuery(factory=self.method)
+        self.assertEqual("method", query.name)
+        self.assertTrue(query.description.startswith(">> method"))
+        self.assertIn("method docstring", query.description)
+
+    def test_should_call_function(self):
+        local_called = 0
+
+        def local_factory(arg):
+            nonlocal local_called
+            local_called += 1
+            return arg
+
+        query = lbuild.query.Query(function=local_factory)
+        retval = query.value(self.env)("arg")
+        self.assertEqual("arg", retval)
+        self.assertEqual(1, local_called)
+
+        retval = query.value(self.env)("arg2")
+        self.assertEqual("arg2", retval)
+        self.assertEqual(2, local_called)
+
+    def test_should_call_property(self):
+        factory_called = 0
+
+        def local_factory(env):
+            nonlocal factory_called
+            factory_called += 1
+            return env
+
+        query = lbuild.query.EnvironmentQuery(factory=local_factory)
+        retval = query.value(self.env)
+        self.assertEqual(self.env, retval)
+        self.assertEqual(1, factory_called)
+
+        retval = query.value(self.env)
+        self.assertEqual(self.env, retval)
+        self.assertEqual(1, factory_called)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
There are several places in modm where the same code needs to be executed by different modules.
For example, the `modm:build` module defines the compiler flags in it's module, and wants to share this with it's submodules. This was worked around by reading the file and `exec()`uting its content in the submodules, however, this is fragile and undocumented and error prone.

This introduces the concept of adding "queries" to a module, that can be accessed from any other module using the name resolution.
A module can add a `Query()`, which wraps any callable object and makes it visible in the module tree (it uses the `__doc__` string and introspects the signature).
A `EnvironmentQuery` returns the result of a function that gets passed a read-only environment. This allows the lazy construction of a property in the build or post-build step.

### Example

In the `modm:build` module, several common functions are added, incl. source files:
```py
module.add_query(
    Query(name="source_files",  function=common_source_files))
```

`lbuild discover --developer` outputs this:
```
 ├── Module(modm:build)   Build System Generators
 ├── StringOption(build.path) = "" in [String: build/game_of_life]
 ├── StringOption(openocd.cfg) = "" in [String]
 ├── StringOption(project.name) = game_of_life in [String]
 ├── Query(source_files)   Builds a list of files that need to be compiled per repository.
 ├── Module(modm:build:cmake)   CMake Build Script Generator
 │   ╰── BooleanOption(include_makefile) = True in [True, False]
```


`lbuild discover -n modm:build --developer` and `lbuild discover -n modm:build:source_files` output this:
```
>> modm:build:source_files(buildlog)  [Query]

Builds a list of files that need to be compiled per repository.

:param buildlog: the buildlog object available in the post_build step
:returns: a dictionary of sorted lists of filenames, keyed by repository.
```

The `modm:build:scons` module can access this function using `env.query`:

```py
sources = env.query("::source_files")(buildlog)
```

### Questions

1. Should this be called `objects`? At the moment I plan to only use this to wrap callable functions.
1. Is a repository allowed to add objects? What would be the use-case?
1. Should this be allowed to add non-callable data? For example, in modm, the `modm:driver` module may provide additional data for its submodules in the form of a dictionary that contains memory maps of external devices via modm-devices. This avoids requiring an option to access this data like with `modm:target`, which would be redundant anyways, since the user is already explicity selecting the driver module already.
1. Should this be visible by default to `lbuild discover`? This isn't accessible by a user, only by a repository developer. Maybe it should only be visible in verbose view `lbuild discover -v`?

### Answers

No. 1: No, query describes the intention much better.

No. 2: Not necessary, since any module can add and access these objects, just like options.

No. 3: Yes, I've added `EnvironmentQuery`.

No. 4: By default the objects are not visible during discover, you must pass `--developer` to the `lbuild discover` command to get this information.

### TODO

- [x] Documentation
- [x] Discoverability and Formatting
- [x] Fix Naming
- [x] Unit Tests

cc @dergraaf @rleh @chris-durand 