### PR TITLE
Make repository configurations discoverable

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,23 +158,24 @@ for this specific repository option:
 Parser(lbuild)
 ╰── Repository(modm @ ../modm)   modm: a barebone embedded library generator
     ├── EnumerationOption(target) = stm32f407vgt in [at90can128, at90can32, at90can64, ...]
-    ├── Module(modm:board)
-    │   ╰── Module(modm:board:disco-f407vg)
-    ├── Module(modm:build)
+    ├── Configuration(modm:disco-f407vg)
+    ├── Module(modm:board)   Board Support Packages
+    │   ╰── Module(modm:board:disco-f469ni)   STM32F469IDISCOVERY
+    ├── Module(modm:build)   Build System Generators
     │   ├── Option(build.path) = build/parent-folder in [String]
     │   ├── Option(project.name) = parent-folder in [String]
     │   ╰── Module(modm:build:scons)  SCons Build Script Generator
     │       ├── BooleanOption(info.build) = False in [True, False]
     │       ╰── EnumerationOption(info.git) = Disabled in [Disabled, Info, Info+Status]
-    ├── Module(modm:platform)
-    │   ├── Module(modm:platform:can)
-    │   │   ╰── Module(modm:platform:can:1) CAN 1 instance
+    ├── Module(modm:platform)   Platform HAL
+    │   ├── Module(modm:platform:can)   Controller Area Network (CAN)
+    │   │   ├── Module(modm:platform:can:1)   Instance 1
     │   │       ├── NumericOption(buffer.rx) = 32 in [1 .. 32 .. 65534]
     │   │       ╰── NumericOption(buffer.tx) = 32 in [1 .. 32 .. 65534]
-    │   ├── Module(modm:platform:core)
+    │   ├── Module(modm:platform:core)   ARM Cortex-M Core
     │   │   ├── EnumerationOption(allocator) = newlib in [block, newlib, tlsf]
-    │   │   ├── NumericOption(main_stack_size) = 3040 in [256 .. 3040 .. 65536]
-    │   │   ╰── EnumerationOption(vector_table_location) = fastest in [fastest, ram, rom]
+    │   │   ├── NumericOption(main_stack_size) = 3072 in [256 .. 3072 .. 65536]
+    │   │   ╰── EnumerationOption(vector_table_location) = rom in [ram, rom]
 ```
 
 You can now discover all module options in more detail:

--- a/lbuild/facade.py
+++ b/lbuild/facade.py
@@ -72,8 +72,8 @@ class RepositoryInitFacade(BaseNodeInitFacade):
     def add_filter(self, name, function):
         self._node._new_filters[name] = function
 
-    def add_configuration(self, name, path):
-        self._node._config_map[name] = path
+    def add_configuration(self, name, path, description=None):
+        self._node.add_configuration(name, path, description)
 
 
 class RepositoryPrepareFacade(BaseNodePrepareFacade):

--- a/lbuild/format.py
+++ b/lbuild/format.py
@@ -23,6 +23,7 @@ SHOW_NODES = {
     lbuild.node.BaseNode.Type.REPOSITORY,
     lbuild.node.BaseNode.Type.MODULE,
     lbuild.node.BaseNode.Type.OPTION,
+    lbuild.node.BaseNode.Type.CONFIG,
 }
 
 COLOR_SCHEME = {
@@ -30,6 +31,7 @@ COLOR_SCHEME = {
     "repository": None,
     "option": None,
     "query": None,
+    "config": None,
     "module": None,
     "description": None,
     "short_description": None,
@@ -224,7 +226,7 @@ def format_node(node, _):
         context = _cw(node.name + " @ " + os.path.relpath(node._filepath, os.getcwd()))
     elif node._type == node.Type.OPTION:
         context = format_option_name(node, fullname=False)
-    if node._type == node.Type.MODULE:
+    elif node._type in [node.Type.MODULE, node.Type.CONFIG]:
         context = _cw(node.fullname).wrap(node)
 
     descr = (_cw(node.__class__.__name__ + "(") + context + _cw(")")).wrap(node)

--- a/lbuild/main.py
+++ b/lbuild/main.py
@@ -21,7 +21,7 @@ from lbuild.format import format_option_short_description
 
 from lbuild.api import Builder
 
-__version__ = '1.7.0'
+__version__ = '1.7.1'
 
 
 class InitAction:

--- a/lbuild/node.py
+++ b/lbuild/node.py
@@ -156,11 +156,15 @@ class BaseNode(anytree.Node):
         PARSER = 1
         REPOSITORY = 2
         OPTION = 3
-        QUERY = 4
-        MODULE = 5
+        CONFIG = 4
+        QUERY = 5
+        MODULE = 6
 
     def __init__(self, name, node_type, repository=None):
         anytree.Node.__init__(self, name)
+        if self.separator in str(name):
+            raise LbuildException("Path separator ':' is not allowed in '{}({})' name!"
+                                  .format(self.__class__.__name__, self.name))
         self._type = node_type
         self._functions = {}
 
@@ -225,6 +229,10 @@ class BaseNode(anytree.Node):
     @property
     def submodules(self):
         return self.all_modules(depth=2)
+
+    @property
+    def configurations(self):
+        return self._findall(self.Type.CONFIG, depth=2)
 
     @property
     def repository(self):

--- a/lbuild/parser.py
+++ b/lbuild/parser.py
@@ -91,7 +91,8 @@ class Parser(BaseNode):
 
             # Parse only new repositories
             for repofile in repofiles:
-                config_map.update(self.parse_repository(repofile)._config_map)
+                repo = self.parse_repository(repofile)
+                config_map.update({c.fullname:c._config for c in repo.configurations})
 
             # nothing more to extend
             if not self._config_flat._extends:

--- a/lbuild/repository.py
+++ b/lbuild/repository.py
@@ -23,6 +23,16 @@ from .exception import LbuildException
 LOGGER = logging.getLogger('lbuild.repository')
 
 
+class Configuration(BaseNode):
+
+    def __init__(self, name, path, description):
+        BaseNode.__init__(self, name, BaseNode.Type.CONFIG)
+        self._config = path
+        if description is None:
+            description = ""
+        self._description = description
+
+
 class Repository(BaseNode):
     """
     A repository is a set of modules.
@@ -38,7 +48,6 @@ class Repository(BaseNode):
         BaseNode.__init__(self, name, self.Type.REPOSITORY, self)
         # Path to the repository file. All relative paths refer to this path.
         self._filename = os.path.realpath(filename)
-        self._config_map = {}
         self._new_filters = {}
 
         # List of module filenames which are later transfered into
@@ -72,12 +81,6 @@ class Repository(BaseNode):
         # Prefix the global filters with the `repo.` name
         for name, func in repo._new_filters.items():
             repo._filters[repo.name + "." + name] = func
-
-        # Prefix the global configuration map with the `repo:` name
-        config_map = repo._config_map.copy()
-        repo._config_map = {}
-        for name, path in config_map.items():
-            repo._config_map[repo.name + ":" + name] = path
 
         return repo
 
@@ -147,6 +150,9 @@ class Repository(BaseNode):
                 if not os.path.isfile(module):
                     raise LbuildException("Module file not found '%s'" % module)
                 self._module_files.append(module)
+
+    def add_configuration(self, name, path, description):
+        self.add_child(Configuration(name, path, description))
 
     def glob(self, pattern):
         pattern = os.path.abspath(self._relocate_relative_path(pattern))


### PR DESCRIPTION
This fixes #5 by adding the config aliases to the discover tree.

Looks like this:
```
 $ lbuild -r repo.lb discover
Parser(lbuild)
╰── Repository(modm @ .)   modm: a barebone embedded library generator
    ├── EnumerationOption(target) = REQUIRED in [...]
    ├── Configuration(modm:al-avreb-can)   AL-AVREB_CAN Board
    ├── Configuration(modm:arduino-uno)   Arduino UNO
    ├── Configuration(modm:black-pill)   Black Pill
    ├── Configuration(modm:blue-pill)   Blue Pill
    ├── Configuration(modm:disco-f051r8)   STM32F0DISCOVERY
    ├── Configuration(modm:disco-f072rb)   STM32F072DISCOVERY
    ├── Configuration(modm:disco-f100rb)   STM32VLDISCOVERY
    ├── Configuration(modm:disco-f303vc)   STM32F3DISCOVERY
    ├── Configuration(modm:disco-f407vg)   STM32F4DISCOVERY
    ├── Configuration(modm:disco-f429zi)   STM32F429IDISCOVERY
    ├── Configuration(modm:disco-f469ni)   STM32F469IDISCOVERY
    ├── Configuration(modm:disco-f746ng)   STM32F7DISCOVERY
    ├── Configuration(modm:disco-f769ni)   STM32F769IDISCOVERY
    ├── Configuration(modm:disco-l476vg)   STM32L476DISCOVERY
    ├── Configuration(modm:nucleo-f031k6)   NUCLEO-F031K6
    ├── Configuration(modm:nucleo-f042k6)   NUCLEO-F042K6
    ├── Configuration(modm:nucleo-f103rb)   NUCLEO-F103RB
    ├── Configuration(modm:nucleo-f303k8)   NUCLEO-F303K8
    ├── Configuration(modm:nucleo-f401re)   NUCLEO-F401RE
    ├── Configuration(modm:nucleo-f411re)   NUCLEO-F411RE
    ├── Configuration(modm:nucleo-f429zi)   NUCLEO-F429ZI
    ├── Configuration(modm:nucleo-g071rb)   NUCLEO-F042K6
    ├── Configuration(modm:nucleo-l432kc)   NUCLEO-L432KC
    ├── Configuration(modm:nucleo-l476rg)   NUCLEO-L476RG
    ├── Configuration(modm:olimexino-stm32)   Olimexino STM32
    ╰── Configuration(modm:stm32f030_demo)   STM32F030 Demo Board
```