### PR TITLE
Add deprecation notices to Facade function in verbose builds

### DIFF
--- a/lbuild/facade.py
+++ b/lbuild/facade.py
@@ -259,6 +259,10 @@ class BuildLogOperationFacade:
     def filename_out(self, path=None):
         return self._operation.local_filename_out(path)
 
+    # deprecated
+    def local_filename_out(self, path=None):
+        return self.filename_out(path)
+
 
 class BuildLogFacade:
 
@@ -269,6 +273,7 @@ class BuildLogFacade:
         self.__repo_metadata = buildlog.repo_metadata
         self.__module_metadata = buildlog.module_metadata
         self.__operation_metadata = buildlog.operation_metadata
+        self.__operations = [BuildLogOperationFacade(operation) for operation in self._buildlog.operations]
 
     @property
     def outpath(self):
@@ -300,13 +305,13 @@ class BuildLogFacade:
 
     @property
     def operations(self):
-        return self._buildlog.operations
+        return self.__operations
 
     def operations_per_module(self, modulename: str):
         return self._buildlog.operations_per_module(modulename)
 
     def __iter__(self):
-        return iter(self._buildlog.operations)
+        return iter(self.__operations)
 
     # deprecated
     def get_operations_per_module(self, modulename: str):

--- a/lbuild/main.py
+++ b/lbuild/main.py
@@ -21,7 +21,7 @@ from lbuild.format import format_option_short_description
 
 from lbuild.api import Builder
 
-__version__ = '1.7.1'
+__version__ = '1.7.2'
 
 
 class InitAction:
@@ -393,6 +393,7 @@ def prepare_argument_parser():
 
 def run(args):
     lbuild.logger.configure_logger(args.verbose)
+    lbuild.facade.VERBOSE_DEPRECATION = args.verbose
     lbuild.format.plain = args.plain
 
     try:


### PR DESCRIPTION
This just renames a few functions for consistency (using `.add_*` prefix for all for example) and reserving `.get*` for options only.

Another issue is that `env.outpath` and `env.outbasepath` are very similar, and if you accidentally write `env.outpath = "path"` it fails silently.

Also fixes that the buildlog operations weren't wrapped in their Facade.

This will format a useful warning message, however, only when doing `lbuild -v build` it will display these as warnings.
