### PR TITLE
Adds type-safe metadata collectors

### DIFF
--- a/README.md
+++ b/README.md
@@ -659,13 +659,20 @@ def add_option_dependencies(value):
 #### StringOption
 
 This is the most generic option, allowing to input any string.
+You may, however, provide your own validator that may raise a `ValueError`
+if the input string does not match your expectations.
 The string is passed unmodified from the configuration to the module and the
 dependency handler.
 
 ```python
+def validate_string(string):
+    if "please" not in string:
+        raise ValueError("Input does not contain the magic word!")
+
 option = StringOption(name="option-name",
                       description="inline", # or FileReader("file.md")
                       default="default string",
+                      validate=validate_string,
                       dependencies=add_option_dependencies)
 ```
 

--- a/README.md
+++ b/README.md
@@ -162,14 +162,14 @@ Parser(lbuild)
     ├── Module(modm:board)   Board Support Packages
     │   ╰── Module(modm:board:disco-f469ni)   STM32F469IDISCOVERY
     ├── Module(modm:build)   Build System Generators
-    │   ├── Option(build.path) = build/parent-folder in [String]
-    │   ├── Option(project.name) = parent-folder in [String]
+    │   ├── PathOption(build.path) = build/parent-folder in [String]
+    │   ├── StringOption(project.name) = parent-folder in [String]
     │   ╰── Module(modm:build:scons)  SCons Build Script Generator
     │       ├── BooleanOption(info.build) = False in [True, False]
     │       ╰── EnumerationOption(info.git) = Disabled in [Disabled, Info, Info+Status]
     ├── Module(modm:platform)   Platform HAL
     │   ├── Module(modm:platform:can)   Controller Area Network (CAN)
-    │   │   ├── Module(modm:platform:can:1)   Instance 1
+    │   │   ╰── Module(modm:platform:can:1)   Instance 1
     │   │       ├── NumericOption(buffer.rx) = 32 in [1 .. 32 .. 65534]
     │   │       ╰── NumericOption(buffer.tx) = 32 in [1 .. 32 .. 65534]
     │   ├── Module(modm:platform:core)   ARM Cortex-M Core
@@ -621,7 +621,7 @@ def post_build(env, buildlog):
 
 *lbuild* options are mappings from strings to Python objects.
 Each option must have a unique name within their parent repository or module.
-If you do not provide a default value, the option is marked as REQUIRED and
+If you do not provide a default value, the option is marked as **REQUIRED** and
 the project cannot be built without it.
 
 ```python
@@ -674,6 +674,26 @@ option = StringOption(name="option-name",
                       default="default string",
                       validate=validate_string,
                       dependencies=add_option_dependencies)
+```
+
+
+#### PathOption
+
+This option operates on strings, but additionally validates them to be
+syntactically valid paths, so the filesystem accepts these strings
+as valid arguments to path operations. This option does not check if the path
+exists, or if it can be created, just if the string is properly formatted.
+
+Since an empty string is not a valid path, but it can be useful to allow an
+empty string as an input value to encode a special case (like a "disable" value),
+you may set `empty_ok=True` to tell the path validation to ignore empty strings.
+
+```python
+option = PathOption(name="option-name",
+                    description="path",
+                    default="path/to/folder/or/file",
+                    empty_ok=False, # is an empty path considered valid?
+                    dependencies=add_option_dependencies)
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -424,7 +424,7 @@ copy and generate files and folders from Jinja2 templates with the substitutions
 of you choice and the configuration of the modules. Each file operation is
 appended to a global build log, which you can also explicitly add metadata to.
 
-The `post_build(env, buildlog)` step is meant for modules that need to generate
+The `post_build(env)` step is meant for modules that need to generate
 files which receive information from all built modules. The typically use-case
 here is generating scripts for build systems, which need to know about what
 files were generated and all module's metadata.
@@ -608,24 +608,26 @@ def build(env):
 # but you can't add to the metadata anymore:
 # - env.collect() unavailable
 # You have access to the entire buildlog up to this point
-def post_build(env, buildlog):
+def post_build(env):
     # The absolute path to the lbuild output directory
-    outpath = buildlog.outpath
+    outpath = env.buildlog.outpath
 
     # All modules that were built
-    modules = buildlog.modules
+    modules = env.buildlog.modules
     # All file generation operations that were done
-    operations = buildlog.operations
+    operations = env.buildlog.operations
     # All operations per module
-    operations = buildlog.operations_per_module("repo:module")
+    operations = env.buildlog.operations_per_module("repo:module")
 
     # iterate over all operations directly
     for operation in buildlog:
         # Get the module name that generated this file
-        env.log.info("Module({}) generated the '{}' file".format(
-                     operation.module_name, operation.filename_out()))
+        env.log.info("Module({}) generated the '{}' file"
+                     .format(operation.module, operation.filename))
         # You can also get the filename relative to a subfolder in outpath
-        operation.filename_out(path="subfolder/")
+        env.relative_output(operation.filename, "subfolder/")
+        # or as an absolute path
+        env.real_output(operation.filename, "subfolder/")
 
     # get all include paths from all active modules
     include_paths = env.collector_values("::include_path")

--- a/lbuild/__init__.py
+++ b/lbuild/__init__.py
@@ -17,6 +17,7 @@ from . import exception
 from . import module
 from . import option
 from . import query
+from . import collector
 from . import parser
 from . import repository
 from . import utils
@@ -25,6 +26,7 @@ from . import main
 __all__ = [
     'builder',
     'buildlog',
+    'collector',
     'environment',
     'exception',
     'facade',

--- a/lbuild/collector.py
+++ b/lbuild/collector.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+#
+# Copyright (c) 2019, Niklas Hauser
+# All Rights Reserved.
+#
+# The file is part of the lbuild project and is released under the
+# 2-clause BSD license. See the file `LICENSE.txt` for the full license
+# governing this code.
+
+from collections import defaultdict, OrderedDict
+
+from .format import ColorWrapper as _cw
+from .node import BaseNode
+from .option import *
+import lbuild.utils
+
+
+class CollectorContext:
+    def __init__(self, module, filename=None):
+        self.module = module
+        self.filename = filename
+
+    @property
+    def repository(self):
+        return self.module.split(":")[0]
+
+    @property
+    def has_filename(self):
+        return self.filename is not None
+
+
+class Collector(BaseNode):
+
+    def __init__(self, option):
+        BaseNode.__init__(self, option.name, BaseNode.Type.COLLECTOR)
+
+        self._option = option
+        self._description = option._description
+        self._values = OrderedDict()
+
+    @property
+    def module(self):
+        return self.parent
+
+    def add_values(self, values, module, operations=None):
+        checked_values = list()
+        for value in lbuild.utils.listify(values):
+            self._option.value = value
+            checked_values.append(self._option.value)
+
+        if operations is not None:
+            for operation in operations:
+                context = CollectorContext(operation.module, operation.filename)
+                self._extend_values(context, checked_values)
+        else:
+            self._extend_values(CollectorContext(module.fullname), checked_values)
+
+    def _extend_values(self, context, values):
+        if context not in self._values:
+            self._values[context] = []
+        self._values[context].extend(values)
+
+    def values(self, default=None, filterfunc=None, unique=True):
+        if filterfunc is None:
+            values = [v  for vs in self._values.values()  for v in vs]
+        else:
+            values = []
+            for context, vals in self._values.items():
+                if filterfunc(context):
+                    values.extend(vals)
+        if unique:
+            values = list(OrderedDict.fromkeys(values))
+        if default is not None and not values:
+            values = lbuild.utils.listify(default)
+        return values
+
+    def items(self):
+        return self._values.items()
+
+    def keys(self):
+        return self._values.keys()
+
+    @property
+    def class_name(self):
+        return self._option.class_name
+
+    def format_values(self):
+        return self._option.format_values()
+
+
+# Inherited Options as Collectors
+
+class StringCollector(StringOption):
+    def __init__(self, name, description, validate=None):
+        StringOption.__init__(self, name, description, validate=validate)
+
+
+class PathCollector(PathOption):
+    def __init__(self, name, description, empty_ok=False):
+        PathOption.__init__(self, name, description, empty_ok=empty_ok)
+
+
+class BooleanCollector(BooleanOption):
+    def __init__(self, name, description):
+        BooleanOption.__init__(self, name, description)
+
+
+class NumericCollector(NumericOption):
+    def __init__(self, name, description, minimum=None, maximum=None):
+        NumericOption.__init__(self, name, description, minimum, maximum)
+
+
+class EnumerationCollector(EnumerationOption):
+    def __init__(self, name, description, enumeration):
+        EnumerationOption.__init__(self, name, description, enumeration)
+
+
+class CallableCollector(Option):
+    def __init__(self, name, description):
+        Option.__init__(self, name, description,
+                        convert_input=self.as_callable,
+                        convert_output=lambda f: f)
+
+    @staticmethod
+    def as_callable(func):
+        if not callable(func):
+            raise ValueError("Object '{}' must be callable!".format(func))
+        return func
+
+    @property
+    def values(self):
+        return ["Callable"]
+
+    def format_values(self):
+        return _cw("Callable")

--- a/lbuild/facade.py
+++ b/lbuild/facade.py
@@ -9,6 +9,7 @@
 # governing this code.
 
 import lbuild.utils
+from .option import OptionSet
 
 
 class BaseNodePrepareFacade:
@@ -66,6 +67,12 @@ class RepositoryInitFacade(BaseNodeInitFacade):
     def add_option(self, option):
         self._node.add_child(option)
 
+    def add_set_option(self, option, default=None):
+        self._node.add_child(OptionSet(option, default))
+
+    def add_query(self, query):
+        self._node.add_child(query)
+
     def add_ignore_patterns(self, *patterns):
         self._node._ignore_patterns.extend(patterns)
 
@@ -109,6 +116,9 @@ class ModulePrepareFacade(BaseNodePrepareFacade):
 
     def add_option(self, option):
         self._node._options.append(option)
+
+    def add_set_option(self, option, default=None):
+        self._node._options.append(OptionSet(option, default))
 
     def add_query(self, query):
         self._node._queries.append(query)

--- a/lbuild/main.py
+++ b/lbuild/main.py
@@ -112,6 +112,8 @@ class DiscoverAction(ManipulationActionBase):
                     ostream.extend(node.values)
                 else:
                     ostream.append(node.description)
+            if not args.values:
+                return "\n\n\n\n".join(ostream)
             return "\n".join(ostream)
 
         return builder.parser.render()

--- a/lbuild/main.py
+++ b/lbuild/main.py
@@ -21,11 +21,10 @@ from lbuild.format import format_option_short_description
 
 from lbuild.api import Builder
 
-__version__ = '1.7.1'
+__version__ = '1.8.0'
 
 
 class InitAction:
-    config_required = True
 
     def register(self, argument_parser):
         parser = argument_parser.add_parser(
@@ -40,7 +39,6 @@ class InitAction:
 
 
 class UpdateAction:
-    config_required = True
 
     def register(self, argument_parser):
         parser = argument_parser.add_parser(
@@ -61,7 +59,6 @@ class ManipulationActionBase:
     All subclasses must implement a `perform` function.
     """
     # pylint: disable=too-few-public-methods
-    config_required = True
 
     def load_repositories(self, args, builder):
         builder.load(args.repositories)
@@ -72,7 +69,6 @@ class ManipulationActionBase:
 
 
 class DiscoverAction(ManipulationActionBase):
-    config_required = False
 
     def register(self, argument_parser):
         parser = argument_parser.add_parser(
@@ -120,7 +116,6 @@ class DiscoverAction(ManipulationActionBase):
 
 
 class DiscoverOptionsAction(ManipulationActionBase):
-    config_required = False
 
     def register(self, argument_parser):
         parser = argument_parser.add_parser(
@@ -156,7 +151,6 @@ class DiscoverOptionsAction(ManipulationActionBase):
 
 
 class ValidateAction(ManipulationActionBase):
-    config_required = False
 
     def register(self, argument_parser):
         parser = argument_parser.add_parser(
@@ -179,7 +173,6 @@ class ValidateAction(ManipulationActionBase):
 
 
 class BuildAction(ManipulationActionBase):
-    config_required = False
 
     def register(self, argument_parser):
         parser = argument_parser.add_parser(
@@ -230,7 +223,6 @@ class BuildAction(ManipulationActionBase):
 
 
 class CleanAction(ManipulationActionBase):
-    config_required = False
 
     def register(self, argument_parser):
         parser = argument_parser.add_parser(
@@ -274,7 +266,6 @@ class CleanAction(ManipulationActionBase):
 
 
 class DependenciesAction(ManipulationActionBase):
-    config_required = False
 
     def register(self, argument_parser):
         parser = argument_parser.add_parser(
@@ -395,7 +386,8 @@ def prepare_argument_parser():
 
 def run(args):
     lbuild.logger.configure_logger(args.verbose)
-    lbuild.format.plain = args.plain
+    lbuild.facade.VERBOSE_DEPRECATION = args.verbose
+    lbuild.format.PLAIN = args.plain
 
     try:
         command = args.execute_action

--- a/lbuild/module.py
+++ b/lbuild/module.py
@@ -108,6 +108,7 @@ class ModuleInit:
         self._dependencies = []
         self._filters = {}
         self._queries = []
+        self._collectors = []
 
     @property
     def fullname(self):
@@ -179,6 +180,9 @@ class Module(BaseNode):
 
         for child in (module._options + module._queries):
             self.add_child(child)
+
+        for collector in module._collectors:
+            self.add_child(lbuild.collector.Collector(collector))
 
         self.add_dependencies(*module._dependencies)
         if ":" in module.parent:

--- a/lbuild/node.py
+++ b/lbuild/node.py
@@ -45,6 +45,7 @@ def load_functions_from_file(repository, filename: str, required, optional=None,
             'EnvironmentQuery': lbuild.query.EnvironmentQuery,
 
             'StringOption': lbuild.option.StringOption,
+            'PathOption': lbuild.option.PathOption,
             'BooleanOption': lbuild.option.BooleanOption,
             'NumericOption': lbuild.option.NumericOption,
             'EnumerationOption': lbuild.option.EnumerationOption,

--- a/lbuild/option.py
+++ b/lbuild/option.py
@@ -27,7 +27,7 @@ class Option(BaseNode):
                  convert_input=None, convert_output=None):
         BaseNode.__init__(self, name, BaseNode.Type.OPTION)
         self._dependency_handler = dependencies
-        self._description = description
+        self.description = description
         self._in = str if convert_input is None else convert_input
         self._out = str if convert_output is None else convert_output
         self._input = None

--- a/lbuild/option.py
+++ b/lbuild/option.py
@@ -336,4 +336,5 @@ class OptionSet(Option):
 
 class SetOption(OptionSet):
     def __init__(self, name, description, enumeration, default=None, dependencies=None):
+        LOGGER.warning("'SetOption(..., default)' is deprecated since v1.8.0, please use 'module.add_set_option(EnumerationOption(...), default)!")
         OptionSet.__init__(self, EnumerationOption(name, description, enumeration, None, dependencies), default)

--- a/lbuild/option.py
+++ b/lbuild/option.py
@@ -21,12 +21,12 @@ from .format import ColorWrapper as _cw
 class Option(BaseNode):
 
     def __init__(self, name, description, default=None, dependencies=None,
-                 convert_input=str, convert_output=str):
+                 convert_input=None, convert_output=None):
         BaseNode.__init__(self, name, BaseNode.Type.OPTION)
         self._dependency_handler = dependencies
         self._description = description
-        self._in = convert_input
-        self._out = convert_output
+        self._in = str if convert_input is None else convert_input
+        self._out = str if convert_output is None else convert_output
         self._input = None
         self._output = None
         self._default = None
@@ -36,7 +36,7 @@ class Option(BaseNode):
         if default is not None:
             self._input = self._in(default)
             self._output = self._out(default)
-            self._default = self._in(default)
+            self._default = self._input
 
     def _update_dependencies(self):
         self._dependencies_resolved = False
@@ -82,8 +82,17 @@ class Option(BaseNode):
 
 class StringOption(Option):
 
-    def __init__(self, name, description, default=None, dependencies=None):
-        Option.__init__(self, name, description, default, dependencies)
+    def __init__(self, name, description, default=None, dependencies=None, validate=None):
+        Option.__init__(self, name, description, None, dependencies,
+                        convert_input=self._validate_string)
+        self._validate = validate
+        self._set_default(default)
+
+    def _validate_string(self, value):
+        value = str(value)
+        if self._validate:
+            self._validate(value)
+        return value
 
 
 class BooleanOption(Option):

--- a/lbuild/option.py
+++ b/lbuild/option.py
@@ -95,6 +95,44 @@ class StringOption(Option):
         return value
 
 
+class PathOption(Option):
+
+    def __init__(self, name, description, default=None, dependencies=None, empty_ok=False):
+        self._empty_ok = empty_ok
+        Option.__init__(self, name, description, default, dependencies,
+                        convert_input=self._validate_path,
+                        convert_output=lambda p: str(p).strip())
+
+    def _validate_path(self, path):
+        path = str(path).strip()
+        if not self.validate(path, self._empty_ok):
+            raise ValueError("Path '{}' is not valid!".format(path))
+        return path
+
+    @staticmethod
+    def validate(path, empty_ok=False):
+        if empty_ok and len(path) == 0:
+            return True
+        if not lbuild.utils.is_pathname_valid(path):
+            return False
+        return True
+
+    @property
+    def values(self):
+        return ["Path"]
+
+    def format_value(self):
+        value = str(self._input).strip()
+        if value == "":
+            value = "[]"
+        return value
+
+    def format_values(self):
+        if self.is_default() or self._default == "":
+            return _cw("Path")
+        return _cw("Path: ") + _cw(str(self._default)).wrap("underlined")
+
+
 class BooleanOption(Option):
 
     def __init__(self, name, description, default=False, dependencies=None):

--- a/lbuild/parser.py
+++ b/lbuild/parser.py
@@ -9,6 +9,7 @@
 # governing this code.
 
 import sys
+import enum
 import os.path
 import random
 import logging
@@ -38,17 +39,29 @@ class Runner:
 
     def validate(self):
         if hasattr(self.node, "validate"):
-            self.node.validate(self.env.facade_validate)
+            self.env.stage = Parser.Stage.VALIDATE
+            self.node.validate(self.env)
 
     def build(self):
-        self.node.build(self.env.facade_build)
+        self.env.stage = Parser.Stage.BUILD
+        self.node.build(self.env)
 
     def post_build(self, buildlog):
         if hasattr(self.node, "post_build"):
-            self.node.post_build(self.env.facade_post_build, BuildLogFacade(buildlog))
+            self.env.stage = Parser.Stage.POST_BUILD
+            self.node.post_build(self.env)
 
 
 class Parser(BaseNode):
+
+    @enum.unique
+    class Stage(enum.IntEnum):
+        """This order of repo/module function calls"""
+        INIT = 1
+        PREPARE = 2
+        VALIDATE = 3
+        BUILD = 4
+        POST_BUILD = 5
 
     def __init__(self, config=None):
         BaseNode.__init__(self, "lbuild", BaseNode.Type.PARSER)

--- a/lbuild/repository.py
+++ b/lbuild/repository.py
@@ -110,7 +110,7 @@ class Repository(BaseNode):
     def build(self, env):
         build = self._functions.get("build", None)
         if build is not None:
-            lbuild.utils.with_forward_exception(self, lambda: build(env))
+            lbuild.utils.with_forward_exception(self, lambda: build(env.facade))
 
     def add_modules_recursive(self, basepath="", modulefile="module.lb", ignore=None):
         """

--- a/test/collector_test.py
+++ b/test/collector_test.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2015-2017, Fabian Greif
+# Copyright (c) 2018, Niklas Hauser
+# All Rights Reserved.
+#
+# The file is part of the lbuild project and is released under the
+# 2-clause BSD license. See the file `LICENSE.txt` for the full license
+# governing this code.
+
+import os
+import sys
+import enum
+import unittest
+
+# Hack to support the usage of `coverage`
+sys.path.append(os.path.abspath("."))
+
+from lbuild.collector import *
+from lbuild.repository import Repository
+
+
+class CollectorTest(unittest.TestCase):
+
+    def setUp(self):
+        self.repo = Repository("path", name="repo")
+        module1 = lbuild.module.ModuleInit(self.repo, "filename")
+        module1.name = "module1"
+        module1.available = True
+
+        module2 = lbuild.module.ModuleInit(self.repo, "filename2")
+        module2.name = "module2"
+        module2.available = True
+
+        self.module1, self.module2 = lbuild.module.build_modules([module1, module2])
+
+        # Disable advanced formatting for a console and use the plain output
+        lbuild.format.PLAIN = True
+
+    def test_should_provide_factsheet(self):
+        collector = Collector(StringCollector("test", "long description"))
+        output = collector.description
+
+        self.assertIn("test  [StringCollector]", output)
+        self.assertNotIn("Value:", output)
+        self.assertIn("Inputs: [String]", output)
+        self.assertIn("long description", output)
+
+    def test_should_access_values(self):
+        collector = Collector(NumericCollector("test", "long description"))
+
+        collector.add_values(1, self.module1)
+        collector.add_values(2, self.module1)
+
+        collector.add_values(2, self.module2)
+        collector.add_values([3, 3], self.module2)
+
+        unique_values = collector.values()
+        unique_values1 = collector.values(filterfunc=lambda s: s.module == "repo:module1")
+        unique_values2 = collector.values(filterfunc=lambda s: s.module == "repo:module2")
+
+        all_values = collector.values(unique=False)
+        all_values1 = collector.values(filterfunc=lambda s: s.module == "repo:module1", unique=False)
+        all_values2 = collector.values(filterfunc=lambda s: s.module == "repo:module2", unique=False)
+
+        self.assertEqual([1, 2, 3], unique_values)
+        self.assertEqual([1, 2], unique_values1)
+        self.assertEqual([2, 3], unique_values2)
+
+        self.assertEqual([1, 2, 2, 3, 3], all_values)
+        self.assertEqual([1, 2], all_values1)
+        self.assertEqual([2, 3, 3], all_values2)
+
+
+    def test_should_be_constructable_from_callable(self):
+        collector = Collector(CallableCollector("test", "long description"))
+        output = collector.description
+
+        self.assertIn("test  [CallableCollector]", output)
+        self.assertIn("Inputs: [Callable]", output)
+        self.assertIn("long description", output)
+
+        def function():
+            pass
+        collector.add_values(function, self.module1)
+        self.assertEqual([function], collector.values())
+
+        self.assertRaises(ValueError, lambda: collector.add_values(1, self.module1))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/option_test.py
+++ b/test/option_test.py
@@ -79,6 +79,37 @@ class OptionTest(unittest.TestCase):
         self.assertIn("Inputs: [String]", output)
         self.assertIn("long description", output)
 
+    def test_should_be_constructable_from_string(self):
+        option = StringOption("test", "description", default="hello")
+        self.assertIn("test  [StringOption]", option.description)
+        self.assertEqual("hello", option.value)
+        option.value = "world"
+        self.assertEqual("world", option.value)
+        option.value = 1
+        self.assertEqual("1", option.value)
+        option.value = None
+        self.assertEqual("None", option.value)
+        option.value = False
+        self.assertEqual("False", option.value)
+
+        def validate_string(value):
+            if "magic" not in value:
+                raise ValueError("magic not in value")
+
+        option = StringOption("test", "description", default="magic",
+                              validate=validate_string)
+        self.assertEqual("magic", option.value)
+        option.value = "magic word"
+        self.assertEqual("magic word", option.value)
+
+        with self.assertRaises(ValueError):
+            option.value = "hello"
+
+        with self.assertRaises(ValueError):
+            StringOption("test", "description", default="hello",
+                         validate=validate_string)
+
+
     def test_should_be_constructable_from_boolean(self):
         option = BooleanOption("test", "description", False)
         self.assertIn("test  [BooleanOption]", option.description)

--- a/test/option_test.py
+++ b/test/option_test.py
@@ -209,10 +209,10 @@ class OptionTest(unittest.TestCase):
             value1 = 1
             value2 = 2
 
-        option = SetOption("test", "description",
-                           default=[TestEnum.value1, TestEnum.value2],
-                           enumeration=TestEnum)
-        self.assertIn("test  [SetOption]", option.description)
+        option = OptionSet(
+                    EnumerationOption("test", "description", enumeration=TestEnum),
+                    default=[TestEnum.value1, TestEnum.value2])
+        self.assertIn("test  [EnumerationSetOption]", option.description)
         self.assertEqual([1, 2], option.value)
 
         with self.assertRaises(ValueError):
@@ -240,9 +240,9 @@ class OptionTest(unittest.TestCase):
             "value1": 1,
             "value2": 2,
         }
-        option = SetOption("test", "description",
-                           default=["value1", "value2"],
-                           enumeration=enum_dict)
+        option = OptionSet(
+                    EnumerationOption("test", "description", enumeration=enum_dict),
+                    default=["value1", "value2"])
         self.assertEqual([1, 2], option.value)
 
         with self.assertRaises(ValueError):
@@ -267,9 +267,9 @@ class OptionTest(unittest.TestCase):
             "value1",
             "value2",
         ]
-        option = SetOption("test", "description",
-                           default=["value1", "value2"],
-                           enumeration=enum_list)
+        option = OptionSet(
+                    EnumerationOption("test", "description", enumeration=enum_list),
+                    default=["value1", "value2"])
         self.assertEqual(["value1", "value2"], option.value)
         with self.assertRaises(ValueError):
             option.value = {"value3"}
@@ -279,9 +279,9 @@ class OptionTest(unittest.TestCase):
             "value1",
             "value2",
         ]
-        option = SetOption("test", "description",
-                           default=["value1", "value1"],
-                           enumeration=enum_list)
+        option = OptionSet(
+                    EnumerationOption("test", "description", enumeration=enum_list),
+                    default=["value1", "value1"])
         self.assertEqual(["value1"], option.value)
 
     def test_should_be_constructable_from_range(self):
@@ -291,9 +291,9 @@ class OptionTest(unittest.TestCase):
         self.assertEqual(10, option.value)
 
     def test_should_be_constructable_from_range_set(self):
-        option = SetOption("test", "description",
-                           default=range(5, 9),
-                           enumeration=range(1, 21))
+        option = OptionSet(
+                    EnumerationOption("test", "description", enumeration=range(1, 21)),
+                    default=range(5, 9))
         self.assertEqual([5, 6, 7, 8], option.value)
 
     def test_should_be_constructable_from_set(self):
@@ -303,9 +303,9 @@ class OptionTest(unittest.TestCase):
         self.assertEqual(10, option.value)
 
     def test_should_be_constructable_from_set_set(self):
-        option = SetOption("test", "description",
-                           default=set(range(5, 9)),
-                           enumeration=set(range(1, 21)))
+        option = OptionSet(
+                    EnumerationOption("test", "description", enumeration=set(range(1, 21))),
+                    default=set(range(5, 9)))
         self.assertEqual({5, 6, 7, 8}, set(option.value))
 
     def test_should_format_boolean_option(self):
@@ -346,9 +346,9 @@ class OptionTest(unittest.TestCase):
             "value1",
             "value2",
         ]
-        option = SetOption("test", "description",
-                           default=["value1", "value2"],
-                           enumeration=enum_list)
+        option = OptionSet(
+                    EnumerationOption("test", "description", enumeration=enum_list),
+                    default=["value1", "value2"])
 
         output = str(lbuild.format.format_option_value_description(option))
         self.assertIn("{value1, value2} in [value1, value2]", output)

--- a/test/option_test.py
+++ b/test/option_test.py
@@ -109,6 +109,36 @@ class OptionTest(unittest.TestCase):
             StringOption("test", "description", default="hello",
                          validate=validate_string)
 
+    def test_should_be_constructable_from_path(self):
+        option = PathOption("test", "description", default="filename.txt")
+        self.assertIn("test  [PathOption]", option.description)
+        self.assertEqual("filename.txt", option.value)
+        option.value = "filename.txt.in"
+        self.assertEqual("filename.txt.in", option.value)
+        option.value = "path/filename.txt"
+        self.assertEqual("path/filename.txt", option.value)
+        option.value = "path/folder"
+        self.assertEqual("path/folder", option.value)
+        option.value = "path/folder/"
+        self.assertEqual("path/folder/", option.value)
+        option.value = "/path/folder/"
+        self.assertEqual("/path/folder/", option.value)
+        option.value = "/"
+        self.assertEqual("/", option.value)
+        option.value = "\tfile \n  "
+        self.assertEqual("file", option.value)
+
+        with self.assertRaises(ValueError):
+            option.value = ""
+        with self.assertRaises(ValueError):
+            option.value = "//"
+        with self.assertRaises(ValueError):
+            option.value = "/folder//"
+        with self.assertRaises(ValueError):
+            option.value = "//folder/"
+
+        option = PathOption("test", "description", default="", empty_ok=True)
+        self.assertEqual("", option.value)
 
     def test_should_be_constructable_from_boolean(self):
         option = BooleanOption("test", "description", False)


### PR DESCRIPTION
This makes the metadata idea more formal by adding environment "collectors":
Collectors are very thin wrappers around the existing Options with the exception of *not* having default values, or dependency handlers.
The changes are made backwards compatible, by not reusing `metadata`, but adding a new `collect` action. You can see the practical changes to a repository in https://github.com/modm-io/modm/pull/174.

Compared to the metadata approach, the collectors are dictionaries of sets, with the key being a scope, containing the module and optionally a file operation.
You can either access the entire collection using `env.collector_values(key, default=None, filterfunc=None, unique=True)`. This combination works pretty well in practice and is more flexible in accessing values and for future additions than the current metadata system.

I've changed how to attach metadata to file operations, by returning a set of scopes from these file operations, that can then be explicitly given to the `env.collect()` method. This makes it easier to reason about the concept of operations in general, and also allows you to filter the operations before passing it to the collect method.

```python
operations = env.copy(...)
# scope is a set of CollectorScope objects so you can add to this:
operations |= env.template(...)
# you can even filter this scope, since this is the same scope that's also passed to the scopefilter later
operations = filter(lambda s: s.filename.endswith(".hpp"), operations)
# Add these values into this operations
env.collect(key, *values, operations=operations)
```

Naming alternatives: Metadata is a bit too generic, that why I used collector, since it "collects" all sorts of information from all the modules.

Prepare:
- `module.add_collector(...)`: maybe `module.add_metadata_sink`?

Validate:
- `env.has_collector(key)`: okish

Build:
- `env.collect(key, *values, operations=None)`: okish. The naming scheme `env.add_*` is reserved for the prepare stage, so this should be an action.

Post-Build:
- `env.collector_values(key, ...)`: Collect all the values for this key. I'm ok with this.
- `env.collector(key)`: returns the raw Collector object. okish

Developer nodes are now rendered as underscored to make them slightly more visible, but not annoyingly visible:
![screenshot 2019-02-22 at 23 35 13](https://user-images.githubusercontent.com/163066/53275235-899cf680-36fa-11e9-88ad-7e15eff0c629.png)


The `StringOption` and `StringCollector` received a validate function, so that inputs can be a little less generic. I use this to validate the string passed to `PathOption` and `PathCollector` to be sure it's at least syntactically correct. Anything more like checking if a file actually exists was too complicated to *describe*, since it's not clear what is an "input" path that already exists, and what is an "output" path that the module is creating. Not sure if that's actually worth the check.

I need to rework how lbuild uses exceptions, since a lot of my new code just uses the base class `LbuildException`, which makes it difficult to filter for exception sources and format them properly (which then doesn't allow me to show the user *where* these exception occurred).

I also made the options show their short description in the tree view. Not sure why that wasn't the case before. Lastly I deprecated a number of methods, however, I'm only showing these warnings on `lbuild -v`, since I wasn't able to print the module that calls these functions.

- [x] Collectors
- [x] Documentation
- [x] More unit tests
- [x] Deprecate old facade API


cc @dergraaf 