### PR TITLE
Improve discoverability with lbuild search command

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,12 @@
 language: python
 python:
-  - "3.5"
-  - "3.6"
-  - "nightly"
-
-# command to install dependencies
-install: "pip install -r requirements.txt"
-
-# command to run tests
+- '3.5'
+- '3.6'
+- nightly
+install: pip install -r requirements.txt
 script: make test
+deploy:
+  provider: pypi
+  user: salkinium
+  password:
+    secure: gJ3UPzn/Tm8WfUBb85d9QfbO6c1XZ2CxoPEjw/Ct221OEmMFnzyfIj4cEQp8oWE/cTp1sZmaFa1We+QjqLbcWIg2dKMD8IZyffSu1V/Rkf5uojkJ6m0uMMWg95YhHEOgBYAtSGoJLFRrBgu8JPRBMHfiWV5GiuFPz2WsIVfmup5gXXH8fEowDPGUEOZFbIUl3nvlWbCYQHbla/wk2NyXdrk/AkOWZfa8U5ZDbm6BZ9I6tGfJn7gS3YXoFrRGTdymOvBaKZfn0TqKtcfpNU6h0VABGUpXHeE2IikUl1RTCX7PbJHd9nrhabfALX7yqil3uyyyCxQW1MyBjzb0PVW4ihvpjjQgjUou6YLZsAga7CaA4cmLFPJwDAjifWWd+X1lP6ueMWifOZwL3SQNP0ou0kj0sLmzoS4QGT4gE3HCPc+B8YC/4sCHEcpTLEZsDDZ92OU+zETncaghZDnfjSFXHzbRbDj32qmhUx6qaqHy62w1Ot4Ij5D1OtsQEH+QY++YuYix42ukyR7SCQHT3pcHdv8omEvMMEZs10ikSc9p/T2GmmKy+7Pv8nFom/kMbUg7fgKSY/qvSQ+KtKmKZWCXb8y/Rm25RIyzxky8oJ2Sq0vdzc9PnyrR36o3jRyxx5BQ0uWgu1w4SHiROMXXuLm2rnIpezrM71OZhIWhuDhRF6g=

--- a/lbuild/format.py
+++ b/lbuild/format.py
@@ -253,7 +253,10 @@ def format_node(node, _):
     return descr.limit(offset)
 
 
-def format_node_tree(node):
+def format_node_tree(node, filterfunc=None):
+    if filterfunc is None:
+        filterfunc = lambda n: n.type in SHOW_NODES
+
     class Renderer(anytree.RenderTree):
         def __init__(self, node):
             anytree.RenderTree.__init__(self, node,
@@ -262,7 +265,7 @@ def format_node_tree(node):
 
         @staticmethod
         def childiter(nodes):
-            nodes = [n for n in nodes if n.type in SHOW_NODES]
+            nodes = [n for n in nodes if filterfunc(n)]
             return sorted(nodes, key=lambda node: (node._type, node.name))
 
         def __str__(self):

--- a/lbuild/main.py
+++ b/lbuild/main.py
@@ -90,6 +90,13 @@ class DiscoverAction(ManipulationActionBase):
             default=False,
             help="Display option values, instead of description")
         parser.add_argument(
+            "-t",
+            "--tree",
+            action="store_true",
+            default=False,
+            dest="show_subtree",
+            help="Show module tree instead of description.")
+        parser.add_argument(
             "--developer",
             action="store_true",
             default=False,
@@ -104,10 +111,13 @@ class DiscoverAction(ManipulationActionBase):
         if args.names:
             ostream = []
             for node in builder.parser.find_all(args.names):
-                if args.values and node.type == node.Type.OPTION:
-                    ostream.extend(node.values)
+                if args.show_subtree:
+                    ostream.append(node.render())
                 else:
-                    ostream.append(node.description)
+                    if args.values and node.type == node.Type.OPTION:
+                        ostream.extend(node.values)
+                    else:
+                        ostream.append(node.description)
             if not args.values:
                 return "\n\n\n\n".join(ostream)
             return "\n".join(ostream)

--- a/lbuild/main.py
+++ b/lbuild/main.py
@@ -76,12 +76,9 @@ class DiscoverAction(ManipulationActionBase):
             help="Render the available repository tree with modules and options. "
                  "You may need to provide options to see the entire tree!")
         parser.add_argument(
-            "-n",
-            "--name",
             dest="names",
             type=str,
-            action="append",
-            default=[],
+            nargs="?",
             help="Select a specific repository, module or option.")
         parser.add_argument(
             "--values",
@@ -101,7 +98,7 @@ class DiscoverAction(ManipulationActionBase):
             action="store_true",
             default=False,
             dest="show_developer_view",
-            help="Show module queries in tree view and descriptions.")
+            help="Show developer nodes in tree view and descriptions.")
         parser.set_defaults(execute_action=self.load_repositories)
 
     @staticmethod
@@ -133,12 +130,9 @@ class DiscoverOptionsAction(ManipulationActionBase):
             help="Display all known option names, current values, allowed inputs and "
                  "short descriptions.")
         parser.add_argument(
-            "-n",
-            "--name",
             dest="names",
             type=str,
-            action="append",
-            default=[],
+            nargs="?",
             help="Select a specific repository or module.")
         parser.set_defaults(execute_action=self.load_repositories)
 
@@ -155,7 +149,7 @@ class DiscoverOptionsAction(ManipulationActionBase):
             if option.short_description:
                 ostream.append("")
                 ostream.append(textwrap.indent(option.short_description, "  "))
-                ostream.append("")
+            ostream.append("")
 
         return "\n".join(ostream)
 

--- a/lbuild/node.py
+++ b/lbuild/node.py
@@ -322,8 +322,8 @@ class BaseNode(anytree.Node):
     def module_resolver(self):
         return NameResolver(self, self.Type.MODULE)
 
-    def render(self):
-        return lbuild.format.format_node_tree(self)
+    def render(self, filterfunc=None):
+        return lbuild.format.format_node_tree(self, filterfunc)
 
     def add_dependencies(self, *dependencies):
         """


### PR DESCRIPTION
This adds a search command to apply regexes passed via the command line to lbuild which applies them to all module descriptions and renders a subtree with the node names as well as all the line of the node descriptions that the regex applied to. Closes #8.

Also adds subtree discovery, for example: `lbuild discover -t modm:platform` only renders the tree from the module onwards.

Looks like this:
![screenshot 2019-02-27 at 21 33 57](https://user-images.githubusercontent.com/163066/53521039-6b0e7500-3ad7-11e9-821d-eef1462db761.png)

