### PR TITLE
Find lbuild.xml recursively and improve config name resolution

### DIFF
--- a/lbuild/api.py
+++ b/lbuild/api.py
@@ -41,17 +41,21 @@ class Builder:
         self.cwd = cwd
 
         try:
-            config = ConfigNode.from_file(config)
+            file_config = ConfigNode.from_file(config)
         except lbuild.exception.LbuildException:
-            config = None
+            file_config = ConfigNode()
+            file_config.filename = "command-line"
+            file_config._extends["command-line"].append(config)
 
-        file_config = ConfigNode.from_filesystem(cwd)
-        if config:
-            config.extend_last(file_config)
+        filesystem_config = ConfigNode.from_filesystem(cwd)
+        if file_config is not None:
+            file_config.extend_last(filesystem_config)
+        elif filesystem_config is not None:
+            file_config = filesystem_config
         else:
-            config = file_config if file_config else ConfigNode()
+            file_config = ConfigNode()
 
-        self.config = config
+        self.config = file_config
         self.config.add_commandline_options(listify(options))
         self.parser = Parser(self.config)
 

--- a/lbuild/main.py
+++ b/lbuild/main.py
@@ -22,7 +22,7 @@ from lbuild.format import format_option_short_description
 
 from lbuild.api import Builder
 
-__version__ = '1.9.2'
+__version__ = '1.10.0'
 
 
 class InitAction:


### PR DESCRIPTION
- Searches for `lbuild.xml` config files all the way to up to the filesystem root and extends them all
- Uses normal name resolution to find the config alias
- Allows using a config alias for command line: `lbuild -r repo.lb -c ":disco-f46*" discover`