### PR TITLE
Better formatting of inputs for NumericOption

### DIFF
--- a/lbuild/main.py
+++ b/lbuild/main.py
@@ -22,7 +22,7 @@ from lbuild.format import format_option_short_description
 
 from lbuild.api import Builder
 
-__version__ = '1.11.0'
+__version__ = '1.11.1'
 
 
 class InitAction:


### PR DESCRIPTION
Prints the input string in the description.

Examples:
```
>>> modm:tlsf:minimum_pool_size  [NumericOption]

Minimum pool size in byte

Value: 2**19 (524288)
Inputs: [2**12 .. 2**19 .. 2**29]
```

```
Module(modm:platform:cortex-m)   ARM Cortex-M Core
├── NumericOption(linkerscript.flash_offset) = 0 in [0 ... 0x40000]   Add an offset to the default start address o ...
╰── NumericOption(main_stack_size) = 3040 in [256 .. 3040 .. 2**16]   Minimum size of the application main stack
```

cc @dergraaf 