### PR TITLE
Fix repository vcs and cache inheritance issues

### DIFF
--- a/lbuild/main.py
+++ b/lbuild/main.py
@@ -22,7 +22,7 @@ from lbuild.format import format_option_short_description
 
 from lbuild.api import Builder
 
-__version__ = '1.11.6'
+__version__ = '1.11.7'
 
 
 class InitAction:

--- a/lbuild/repository.py
+++ b/lbuild/repository.py
@@ -149,6 +149,7 @@ class Repository(BaseNode):
     def build(self, env):
         build = self._functions.get("build", None)
         if build is not None:
+            LOGGER.info("Build %s", self.fullname)
             lbuild.utils.with_forward_exception(self, lambda: build(env.facade))
 
     def add_modules_recursive(self, basepath="", modulefile="module.lb", ignore=None):

--- a/lbuild/vcs/common.py
+++ b/lbuild/vcs/common.py
@@ -26,6 +26,7 @@ def _parse_vcs(config: lbuild.config.ConfigNode,
                action):
     LOGGER.debug("Initialize VCS repositories")
 
+    config = config.flatten()
     for vcs in config.vcs:
         for tag, repoconfig in vcs.items():
             if tag == "git":

--- a/test/api_test.py
+++ b/test/api_test.py
@@ -37,7 +37,7 @@ class ApiTest(unittest.TestCase):
             "modules": list(),
             "repositories": list(),
             "vcs": list(),
-            "cachefolder": Path(),
+            "cachefolder": ".lbuild_cache",
         }
         defaults.update(kw)
         for key, default in defaults.items():

--- a/test/config_test.py
+++ b/test/config_test.py
@@ -13,9 +13,10 @@ import os
 import sys
 import unittest
 
+
 # Hack to support the usage of `coverage`
 sys.path.append(os.path.abspath("."))
-from os.path import join
+from os.path import join, abspath
 
 import lbuild
 from lbuild.config import ConfigNode
@@ -42,6 +43,7 @@ class ConfigTest(unittest.TestCase):
         self.assertEqual(1, len(config.modules))
         self.assertIn(":module1", config.modules)
         self.assertIn(self._get_path("repo1.lb"), config.repositories)
+        self.assertEqual(self._get_path(".lbuild_cache"), abspath(config.cachefolder))
 
         # Multiple lbuild.xml
         config = self._find_config("configfile/")
@@ -51,6 +53,7 @@ class ConfigTest(unittest.TestCase):
         self.assertIn(":module2", config.modules)
         self.assertIn(self._get_path("repo1.lb"), config.repositories)
         self.assertIn(self._get_path("configfile/repo2.lb"), config.repositories)
+        self.assertEqual(self._get_path("configfile/put/cache/in/.lbuild_cache"), abspath(config.cachefolder))
 
         # non-existant file name
         config = self._find_config("configfile/", name="television_rules_the_nation.xml")
@@ -65,6 +68,7 @@ class ConfigTest(unittest.TestCase):
             config = self._parse_config("non-existant.xml")
 
         config = self._parse_config("configfile/project.xml")
+        self.assertEqual(self._get_path("configfile/hello_there"), abspath(config.cachefolder))
 
         modules = config.modules
         self.assertEqual(4, len(modules))
@@ -85,6 +89,7 @@ class ConfigTest(unittest.TestCase):
 
     def test_should_parse_base_configuration(self):
         config = self._parse_config("configfile_inheritance/depth_0.xml")
+        self.assertEqual(self._get_path("configfile_inheritance/.lbuild_cache"), abspath(config.cachefolder))
 
         self.assertEqual(1, len(config.repositories))
         self.assertIn(self._get_path("configfile_inheritance/repo3.lb"), config.repositories)
@@ -98,6 +103,7 @@ class ConfigTest(unittest.TestCase):
 
     def test_should_inherit_configuration(self):
         config = self._parse_config("configfile_inheritance/depth_1a.xml")
+        self.assertEqual(self._get_path("configfile_inheritance/.lbuild_cache"), abspath(config.cachefolder))
 
         self.assertEqual(2, len(config.repositories))
         self.assertIn(self._get_path("configfile_inheritance/repo1.lb"), config.repositories)

--- a/test/resources/config/configfile/lbuild.xml
+++ b/test/resources/config/configfile/lbuild.xml
@@ -4,6 +4,7 @@
 		<repository>
 			<path>repo2.lb</path>
 		</repository>
+		<cache>put/cache/in/.lbuild_cache</cache>
 	</repositories>
 
 	<options>

--- a/test/resources/config/configfile/project.xml
+++ b/test/resources/config/configfile/project.xml
@@ -7,6 +7,7 @@
 		<repository>
 			<path>repo2/repo2.lb</path>
 		</repository>
+		<cache>hello_there/</cache>
 	</repositories>
 
 	<options>


### PR DESCRIPTION
When using the VCS, the config tree wasn't flattened, and thus inherited configs were ignored.
This fixes the issue and also correctly deals with overwriting the `repository/cache` key when inheriting.

cc @dergraaf 