### PR TITLE
Make VCS branch entry optional

### DIFF
--- a/lbuild/config.py
+++ b/lbuild/config.py
@@ -231,7 +231,7 @@ class ConfigNode(anytree.AnyNode):
                 lxml.etree.XIncludeError) as error:
             # lxml.etree has the used exception, but pylint is not able to detect them:
             # pylint: disable=no-member
-            raise LbuildConfigException(configfile, error)
+            raise LbuildConfigException(configfile, ": Validation failed!\n\n{}".format(error))
         return xmltree
 
     @staticmethod

--- a/lbuild/main.py
+++ b/lbuild/main.py
@@ -22,7 +22,7 @@ from lbuild.format import format_option_short_description
 
 from lbuild.api import Builder
 
-__version__ = '1.11.7'
+__version__ = '1.11.8'
 
 
 class InitAction:

--- a/lbuild/resources/configuration.xsd
+++ b/lbuild/resources/configuration.xsd
@@ -4,17 +4,17 @@
   <xsd:element name="library">
     <xsd:complexType>
       <xsd:choice maxOccurs="unbounded">
-        <xsd:element name="repositories" type="RepositoriesType" minOccurs="0" maxOccurs="1" />
-        <xsd:element name="extends" type="xsd:string" minOccurs="0" maxOccurs="unbounded" />
-        <xsd:element name="options" type="OptionsType" minOccurs="0" maxOccurs="1" />
-        <xsd:element name="modules" type="ModulesType" minOccurs="0" maxOccurs="1" />
+        <xsd:element name="repositories" type="RepositoriesType" minOccurs="0" maxOccurs="1"/>
+        <xsd:element name="extends" type="xsd:string" minOccurs="0" maxOccurs="unbounded"/>
+        <xsd:element name="options" type="OptionsType" minOccurs="0" maxOccurs="1"/>
+        <xsd:element name="modules" type="ModulesType" minOccurs="0" maxOccurs="1"/>
       </xsd:choice>
     </xsd:complexType>
   </xsd:element>
 
   <xsd:complexType name="RepositoriesType">
     <xsd:choice maxOccurs="unbounded">
-      <xsd:element name="repository" type="RepositoryType" minOccurs="0" maxOccurs="unbounded" />
+      <xsd:element name="repository" type="RepositoryType" minOccurs="0" maxOccurs="unbounded"/>
       <xsd:element name="cache" type="xsd:anyURI" minOccurs="0" maxOccurs="1">
         <xsd:annotation>
           <xsd:documentation>
@@ -28,14 +28,14 @@
   <xsd:complexType name="RepositoryType">
     <xsd:sequence>
       <xsd:element name="vcs" type="VersionControlType" minOccurs="0" maxOccurs="1"/>
-      <xsd:element name="path" type="xsd:string" minOccurs="1" maxOccurs="1" />
+      <xsd:element name="path" type="xsd:string" minOccurs="1" maxOccurs="1"/>
     </xsd:sequence>
   </xsd:complexType>
 
   <xsd:complexType name="VersionControlType">
     <xsd:choice minOccurs="0" maxOccurs="unbounded">
-      <xsd:element name="git" type="GitRepositoryType" />
-      <!-- <xsd:element name="svn" type="SubversionRepositoryType" /> -->
+      <xsd:element name="git" type="GitRepositoryType"/>
+      <!-- <xsd:element name="svn" type="SubversionRepositoryType"/> -->
     </xsd:choice>
   </xsd:complexType>
 
@@ -48,14 +48,14 @@
           </xsd:documentation>
         </xsd:annotation>
       </xsd:element>
-      <xsd:element name="url" type="xsd:anyURI" />
-      <xsd:element name="branch" type="xsd:string"/>
+      <xsd:element name="url" type="xsd:anyURI"/>
+      <xsd:element name="branch" type="xsd:string" minOccurs="0" maxOccurs="1"/>
       <xsd:choice minOccurs="0">
         <xsd:element name="commit">
           <xsd:simpleType>
             <xsd:restriction base="xsd:hexBinary">
-              <xsd:minLength value="4" />
-              <xsd:maxLength value="40" />
+              <xsd:minLength value="4"/>
+              <xsd:maxLength value="40"/>
             </xsd:restriction>
           </xsd:simpleType>
         </xsd:element>
@@ -71,22 +71,22 @@
 
   <xsd:complexType name="OptionsType">
     <xsd:sequence>
-      <xsd:element name="option" type="OptionType" minOccurs="0" maxOccurs="unbounded" />
+      <xsd:element name="option" type="OptionType" minOccurs="0" maxOccurs="unbounded"/>
     </xsd:sequence>
   </xsd:complexType>
 
   <xsd:complexType name="OptionType">
     <xsd:simpleContent>
       <xsd:extension base="xsd:string">
-        <xsd:attribute name="name" type="xsd:string" />
-        <xsd:attribute name="value" type="xsd:string" />
+        <xsd:attribute name="name" type="xsd:string"/>
+        <xsd:attribute name="value" type="xsd:string"/>
       </xsd:extension>
     </xsd:simpleContent>
   </xsd:complexType>
 
   <xsd:complexType name="ModulesType">
     <xsd:sequence>
-      <xsd:element name="module" type="xsd:string" minOccurs="0" maxOccurs="unbounded" />
+      <xsd:element name="module" type="xsd:string" minOccurs="0" maxOccurs="unbounded"/>
     </xsd:sequence>
   </xsd:complexType>
 </xsd:schema>

--- a/lbuild/vcs/git.py
+++ b/lbuild/vcs/git.py
@@ -23,8 +23,8 @@ class Repository:
 
         self.name = config["name"]
         self.url = config["url"]
-        self.branch = config["branch"]
-        self.commit = config.get("commit", None)
+        self.branch = config.get("branch")
+        self.commit = config.get("commit")
 
         self.localpath = os.path.join(cachefolder, self.name)
         self._repo = None
@@ -32,26 +32,25 @@ class Repository:
     def get_repository(self):
         if self._repo is None:
             if os.path.exists(self.localpath):
-                LOGGER.debug("Found existing repository in %s", self.localpath)
+                LOGGER.info("Found existing repository in '%s'", os.path.relpath(self.localpath))
                 self._repo = git.Repo(self.localpath)
             else:
-                LOGGER.info("Initialize new repository in %s", self.localpath)
-                self._repo = git.Repo.clone_from(self.url,
-                                                 self.localpath,
-                                                 branch=self.branch)
+                LOGGER.info("Cloning repository '%s' into '%s'", self.name, os.path.relpath(self.localpath))
+                self._repo = git.Repo.clone_from(self.url, self.localpath)
         return self._repo
 
     def initialize(self):
         repo = self.get_repository()
         if self.commit is not None:
             self.switch_to_commit(repo, self.commit)
-        else:
+        elif self.branch is not None:
             self.switch_to_branch(repo, self.branch)
+        LOGGER.info("Updating submodules recursively")
         repo.git.submodule('update', '--init', '--recursive')
 
     def update(self):
         repo = self.get_repository()
-        LOGGER.debug("Pull from origin")
+        LOGGER.info("Updating repository '%s' from origin", self.name)
         origin = repo.remotes.origin
         origin.pull()
         repo.git.submodule('sync')
@@ -60,7 +59,7 @@ class Repository:
     @staticmethod
     def switch_to_commit(repo, commit):
         if not repo.head.commit.hexsha.startswith(commit):
-            LOGGER.debug("Switch to commit '%s'", commit)
+            LOGGER.info("Switching to commit '%s'", commit)
             past_branch = repo.create_head("past_branch", commit)
             repo.head.reference = past_branch
             repo.head.reset(index=True, working_tree=True)
@@ -70,7 +69,6 @@ class Repository:
     def switch_to_branch(repo, branch):
         active_branch = repo.active_branch
         if str(active_branch) != branch:
-            LOGGER.debug("Switch to branch '%s' from '%s'", branch, active_branch)
-
+            LOGGER.info("Switching from branch '%s' to '%s'", active_branch, branch)
             git_cmd = repo.git
             git_cmd.checkout(branch)

--- a/test/git_test.py
+++ b/test/git_test.py
@@ -37,10 +37,12 @@ class GitTest(unittest.TestCase):
         with tarfile.TarFile(self._get_path("repository.tar")) as archive:
             archive.extractall(tempdir.path)
 
-    def prepare_config_file(self, tempdir, branch, commit=""):
+    def prepare_config_file(self, tempdir, branch="", commit=""):
         config_filename = tempdir.getpath("config.xml")
         localpath = tempdir.getpath("source")
         url = tempdir.getpath("repository")
+        branch = "<branch>{}</branch>".format(branch) if branch else ""
+        commit = "<commit>{}</commit>".format(commit) if commit else ""
 
         with open(config_filename, "w") as config_file:
             with open(self._get_path("config.xml.in")) as template:
@@ -67,7 +69,7 @@ class GitTest(unittest.TestCase):
     @testfixtures.tempdir(ignore=[".git/"])
     def test_should_initialize_repository(self, tempdir):
         self.prepare_git_repository(tempdir)
-        config_file = self.prepare_config_file(tempdir, branch="master")
+        config_file = self.prepare_config_file(tempdir)
         args = self.prepare_arguments(config_file, ["init", ])
 
         # Run the command
@@ -84,7 +86,7 @@ class GitTest(unittest.TestCase):
     @testfixtures.tempdir(ignore=[".git/"])
     def test_should_initialize_repository_multiple_times(self, tempdir):
         self.prepare_git_repository(tempdir)
-        config_file = self.prepare_config_file(tempdir, branch="master")
+        config_file = self.prepare_config_file(tempdir)
         args = self.prepare_arguments(config_file, ["init", ])
 
         # Run the command
@@ -106,7 +108,7 @@ class GitTest(unittest.TestCase):
         self.prepare_git_repository(tempdir)
 
         # Add existing source directory with default checkout of 'master' branch
-        config_file = self.prepare_config_file(tempdir, branch="master")
+        config_file = self.prepare_config_file(tempdir)
         args = self.prepare_arguments(config_file, ["init", ])
         lbuild.main.run(args)
 
@@ -134,7 +136,7 @@ class GitTest(unittest.TestCase):
         warnings.simplefilter("ignore", ResourceWarning)
 
         self.prepare_git_repository(tempdir)
-        config_file = self.prepare_config_file(tempdir, branch="master")
+        config_file = self.prepare_config_file(tempdir)
         args = self.prepare_arguments(config_file, ["init", ])
 
         # Run the command
@@ -176,8 +178,8 @@ class GitTest(unittest.TestCase):
     def test_should_initialize_repository_with_head_commit(self, tempdir):
         self.prepare_git_repository(tempdir)
         config_file = self.prepare_config_file(tempdir,
-                                               branch="develop",
-                                               commit="<commit>fbfc82c8f77c7bb8676925a0f1dce196a55f1140</commit>")
+                                               branch="ignored",
+                                               commit="fbfc82c8f77c7bb8676925a0f1dce196a55f1140")
         args = self.prepare_arguments(config_file, ["init", ])
 
         # Run the command
@@ -197,8 +199,8 @@ class GitTest(unittest.TestCase):
     def test_should_initialize_repository_with_different_commit(self, tempdir):
         self.prepare_git_repository(tempdir)
         config_file = self.prepare_config_file(tempdir,
-                                               branch="develop",
-                                               commit="<commit>1671afbce8453c1e6c0f4c94c6d9ede2c5f49991</commit>")
+                                               branch="ignored",
+                                               commit="1671afbce8453c1e6c0f4c94c6d9ede2c5f49991")
         args = self.prepare_arguments(config_file, ["init", ])
 
         # Run the command

--- a/test/resources/git/config.xml.in
+++ b/test/resources/git/config.xml.in
@@ -6,7 +6,7 @@
         <git>
           <name>{localpath}</name>
           <url>{url}</url>
-          <branch>{branch}</branch>
+          {branch}
           {commit}
         </git>
       </vcs>


### PR DESCRIPTION
Fixes #26 by making the branch entry optional and cloning the default branch.
If a commit is specified, the branch information is ignored.

cc @dergraaf @cajt
