### PR TITLE
Allow adding collector values via configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -955,12 +955,24 @@ def post_build(env):
 Note that collector values that were added by a module without explicit
 operations do not have filename, only module names!
 
-You can discover all the available collectors in your repository using
-`lbuild discover --developer`.
-
-Note that collectors are implemented using the same type-safe mechanisms as
+Collectors are implemented using the same type-safe mechanisms as
 [Options](#Options), the only differences are the lack of dependency handlers
 and default values, since you can add default values in the modules build step.
+
+You may add collector values via the project configuration. However, since these
+collector values cannot be overwritten by inheriting configurations use this with care.
+
+```xml
+<library>
+  <collectors>
+    <collect name="repo:collector_name">value</collect>
+    <collect name="repo:collector_name">value2</collect>
+  </collectors>
+</library>
+```
+
+You can discover all the available collectors in your repository using
+`lbuild discover --developer`.
 
 
 #### CallableCollector

--- a/lbuild/api.py
+++ b/lbuild/api.py
@@ -98,7 +98,7 @@ class Builder:
         self._load_repositories(repos)
         self._load_modules()
 
-    def validate(self, modules=None):
+    def validate(self, modules=None, complete=True):
         """
         Generate and validate the required set of modules.
 
@@ -107,13 +107,14 @@ class Builder:
 
         Args:
             modules -- List of modules which should be validated.
+            complete -- Simulate a complete build to validate build and post-build steps.
 
         Returns:
             List of modules required for the given modules (after
             resolving dependencies).
         """
         build_modules = self._filter_modules(modules)
-        self.parser.validate_modules(build_modules)
+        self.parser.validate_modules(build_modules, complete)
         return build_modules
 
     def build(self, outpath, modules=None, simulate=False):
@@ -130,6 +131,5 @@ class Builder:
         """
         build_modules = self._filter_modules(modules)
         buildlog = BuildLog(outpath)
-        lbuild.environment.SIMULATE = simulate
-        self.parser.build_modules(build_modules, buildlog)
+        self.parser.build_modules(build_modules, buildlog, simulate=simulate)
         return buildlog

--- a/lbuild/api.py
+++ b/lbuild/api.py
@@ -24,7 +24,7 @@ from lbuild.utils import listify, listrify
 
 class Builder:
 
-    def __init__(self, cwd=None, config=None, options=None):
+    def __init__(self, cwd=None, config=None, options=None, collectors=None):
         """
         Build instance to invoke lbuild methods.
 
@@ -34,6 +34,8 @@ class Builder:
             config -- Path to a configuration file. If specified options,
                 repositories etc. will be loaded from there.
             options -- List of options. Must be list of strings in a
+                "key=value" format.
+            collectors -- List of collector values. Must be list of strings in a
                 "key=value" format.
         """
         if cwd is None:
@@ -71,6 +73,7 @@ class Builder:
 
         self.config = file_config
         self.config.add_commandline_options(listify(options))
+        self.config.add_commandline_collectors(listify(collectors))
         self.parser = Parser(self.config)
 
     def _load_repositories(self, repos=None):

--- a/lbuild/buildlog.py
+++ b/lbuild/buildlog.py
@@ -9,6 +9,7 @@
 # 2-clause BSD license. See the file `LICENSE.txt` for the full license
 # governing this code.
 
+import os
 import logging
 import collections
 import threading
@@ -76,10 +77,10 @@ class BuildLog:
     a specific file.
     """
 
-    def __init__(self, outpath):
+    def __init__(self, outpath=None):
         self._operations = collections.defaultdict(list)
         self._metadata = collections.defaultdict(lambda: collections.defaultdict(set))
-        self.outpath = abspath(outpath)
+        self.outpath = os.getcwd() if outpath is None else abspath(outpath)
 
         self._build_files = {}
         self.__lock = threading.RLock()

--- a/lbuild/format.py
+++ b/lbuild/format.py
@@ -24,6 +24,7 @@ SHOW_NODES = {
     lbuild.node.BaseNode.Type.MODULE,
     lbuild.node.BaseNode.Type.OPTION,
     lbuild.node.BaseNode.Type.CONFIG,
+    lbuild.node.BaseNode.Type.COLLECTOR,
 }
 
 COLOR_SCHEME = {
@@ -225,16 +226,18 @@ def format_short_description(_, description):
 
 
 def format_node(node, _, depth):
+    class_name = _cw(node._type.name.capitalize())
+    if node._type == node.Type.QUERY:
+        class_name = class_name.wrap("underlined")
+
     name = _cw(node.name)
-    class_name = _cw(node.class_name)
     if node._type == node.Type.REPOSITORY:
         name = _cw(node.name + " @ " + os.path.relpath(node._filepath))
     elif node._type == node.Type.OPTION:
         name = format_option_name(node, fullname=False)
-    elif node._type in [node.Type.MODULE, node.Type.CONFIG]:
+    elif node._type in {node.Type.MODULE, node.Type.CONFIG}:
         name = _cw(node.fullname).wrap(node)
-    elif node._type in [node.Type.QUERY, node.Type.COLLECTOR]:
-        class_name = class_name.wrap("underlined")
+    elif node._type in {node.Type.QUERY, node.Type.COLLECTOR}:
         name = name.wrap("bold")
 
     descr = (class_name + _cw("(") + name + _cw(")")).wrap(node)

--- a/lbuild/format.py
+++ b/lbuild/format.py
@@ -228,7 +228,7 @@ def format_node(node, _, depth):
     name = _cw(node.name)
     class_name = _cw(node.class_name)
     if node._type == node.Type.REPOSITORY:
-        name = _cw(node.name + " @ " + os.path.relpath(node._filepath, os.getcwd()))
+        name = _cw(node.name + " @ " + os.path.relpath(node._filepath))
     elif node._type == node.Type.OPTION:
         name = format_option_name(node, fullname=False)
     elif node._type in [node.Type.MODULE, node.Type.CONFIG]:

--- a/lbuild/main.py
+++ b/lbuild/main.py
@@ -242,22 +242,19 @@ class ValidateAction(ManipulationActionBase):
             dest="modules",
             type=str,
             action="append",
-            default=[],
+            default=[":**"],
             help="Select a specific module.")
         parser.add_argument(
-            "--all",
-            dest="validate_all",
+            "--fast",
+            dest="validate_fast",
             action="store_true",
             default=False,
-            help="Validate all available module and simulate a build on them.")
+            help="Run only validation steps not build and post-build.")
         parser.set_defaults(execute_action=self.load_repositories)
 
     @staticmethod
     def perform(args, builder):
-        if args.validate_all:
-            builder.build(args.path, [":**"], simulate=True)
-        else:
-            builder.validate(args.modules)
+        builder.validate(args.modules, complete=not args.validate_fast)
         return "Library configuration valid."
 
 

--- a/lbuild/main.py
+++ b/lbuild/main.py
@@ -22,7 +22,7 @@ from lbuild.format import format_option_short_description
 
 from lbuild.api import Builder
 
-__version__ = '1.11.8'
+__version__ = '1.12.0'
 
 
 class InitAction:
@@ -432,6 +432,15 @@ def prepare_argument_parser():
              "from the configuration file and will overwrite the configuration "
              "file definitions.")
     argument_parser.add_argument(
+        '--collect',
+        metavar='COLLECTOR',
+        dest='collectors',
+        action='append',
+        type=str,
+        default=[],
+        help="Additional collectors. Values given here will be merged with collectors "
+             "from the configuration file.")
+    argument_parser.add_argument(
         '-v',
         '--verbose',
         action='count',
@@ -482,7 +491,7 @@ def run(args):
     except AttributeError:
         raise lbuild.exception.LbuildArgumentException("No command specified!")
 
-    builder = Builder(config=args.config, options=args.options)
+    builder = Builder(config=args.config, options=args.options, collectors=args.collectors)
     return command(args, builder)
 
 

--- a/lbuild/option.py
+++ b/lbuild/option.py
@@ -131,7 +131,7 @@ class PathOption(Option):
             raise TypeError("Input must be a path!")
         # Relocate path to be relative to the user's perspective
         if self._relocate(path):
-            path = os.path.relpath(self._relocate_path(path), os.getcwd())
+            path = os.path.relpath(self._relocate_path(path))
         return path
 
     @staticmethod

--- a/lbuild/parser.py
+++ b/lbuild/parser.py
@@ -149,10 +149,9 @@ class Parser(BaseNode):
                 option._filename = filename
                 option.value = value
             except le.LbuildOptionException as error:
-                raise le.LbuildDumpConfigException(
-                    "Failed to validate repository options!\n{}".format(error), self)
+                raise le.LbuildParserOptionInvalidException(self, error, filename)
             except le.LbuildResolverNoMatchException as error:
-                raise le.LbuildParserNodeNotFoundException(self, name, self.Type.OPTION)
+                raise le.LbuildParserNodeNotFoundException(self, name, self.Type.OPTION, filename)
 
 
     def prepare_repositories(self):
@@ -185,10 +184,9 @@ class Parser(BaseNode):
                 option._filename = filename
                 option.value = value
             except le.LbuildOptionException as error:
-                raise le.LbuildDumpConfigException(
-                    "Failed to validate module options!\n{}".format(error), self)
+                raise le.LbuildParserOptionInvalidException(self, error, filename)
             except le.LbuildResolverNoMatchException as error:
-                raise le.LbuildParserNodeNotFoundException(self, name, self.Type.OPTION)
+                raise le.LbuildParserNodeNotFoundException(self, name, self.Type.OPTION, filename)
 
     def resolve_dependencies(self, requested_modules, depth=sys.maxsize):
         """

--- a/lbuild/parser.py
+++ b/lbuild/parser.py
@@ -284,6 +284,17 @@ class Parser(BaseNode):
             env = lbuild.environment.Environment(node, buildlog)
             groups[node.depth].append(Runner(node, env))
 
+        # Merge config collectors values
+        resolver = self.collector_available_resolver
+        for (name, value, filename) in self.config.collectors:
+            try:
+                collector = resolver[name]
+                collector.add_values(value, collector.repository, filename=filename)
+            except le.LbuildOptionException as error:
+                raise le.LbuildParserOptionInvalidException(self, error, filename)
+            except le.LbuildResolverNoMatchException as error:
+                raise le.LbuildParserNodeNotFoundException(self, name, self.Type.COLLECTOR, filename)
+
         exceptions = []
         # Enforce that the submodules are always build before their parent modules
         for index in sorted(groups, reverse=True):

--- a/lbuild/query.py
+++ b/lbuild/query.py
@@ -26,7 +26,9 @@ class Query(BaseNode):
                 raise LbuildQueryConstructionException(self, "'{}' must have a name!".format(function))
             self.name = fname
 
-        self._description = str(inspect.getdoc(function))
+        descr = inspect.getdoc(function)
+        if descr is not None:
+            self._description = descr
         self.suffix = str(inspect.signature(function))
         self._function = function
 

--- a/lbuild/resources/configuration.xsd
+++ b/lbuild/resources/configuration.xsd
@@ -8,6 +8,7 @@
         <xsd:element name="extends" type="xsd:string" minOccurs="0" maxOccurs="unbounded"/>
         <xsd:element name="options" type="OptionsType" minOccurs="0" maxOccurs="1"/>
         <xsd:element name="modules" type="ModulesType" minOccurs="0" maxOccurs="1"/>
+        <xsd:element name="collectors" type="CollectorsType" minOccurs="0" maxOccurs="1" />
       </xsd:choice>
     </xsd:complexType>
   </xsd:element>
@@ -72,6 +73,12 @@
   <xsd:complexType name="OptionsType">
     <xsd:sequence>
       <xsd:element name="option" type="OptionType" minOccurs="0" maxOccurs="unbounded"/>
+    </xsd:sequence>
+  </xsd:complexType>
+
+  <xsd:complexType name="CollectorsType">
+    <xsd:sequence>
+      <xsd:element name="collect" type="OptionType" minOccurs="0" maxOccurs="unbounded" />
     </xsd:sequence>
   </xsd:complexType>
 

--- a/test/parser_test.py
+++ b/test/parser_test.py
@@ -161,6 +161,18 @@ class ParserTest(unittest.TestCase):
         self.assertEqual("tree", options["repo2:target"].value)
         self.assertEqual(True, options["repo2:include_tests"].value)
 
+    def test_should_merge_collectors(self):
+        self.parser.parse_repository(self._get_path("combined/repo1.lb"))
+        self.parser.parse_repository(self._get_path("combined/repo2/repo2.lb"))
+        self.parser._config_flat = lbuild.config.ConfigNode.from_file(self._get_path("combined/test1.xml"))
+        self.parser.merge_repository_options()
+        options = self.parser.repo_options
+
+        self.assertEqual("hosted", options["repo1:target"].value)
+        self.assertEqual(43, options["repo1:foo"].value)
+        self.assertEqual("tree", options["repo2:target"].value)
+        self.assertEqual(True, options["repo2:include_tests"].value)
+
     def test_should_select_available_modules(self):
         self.parser.parse_repository(self._get_path("combined/repo1.lb"))
         self.parser.parse_repository(self._get_path("combined/repo2/repo2.lb"))
@@ -255,6 +267,17 @@ class ParserTest(unittest.TestCase):
         self.parser.merge_module_options()
         with self.assertRaises(le.LbuildConfigNoModulesException):
             self.parser.build_modules([], None)
+
+    def test_should_collect_values(self):
+        build_modules, config_options = self._get_build_modules()
+        module_options = self.parser.merge_module_options()
+
+        self.parser.build_modules(build_modules, simulate=True)
+
+        values = self.parser.collector_values_resolver["::cllctr"]
+        self.assertIn("hello", values)
+        self.assertIn("world", values)
+        self.assertIn("wallaby", values)
 
     @testfixtures.tempdir()
     def test_should_build_modules(self, tempdir):

--- a/test/parser_test.py
+++ b/test/parser_test.py
@@ -234,11 +234,14 @@ class ParserTest(unittest.TestCase):
             self._get_build_modules({"repo1:other:NOPE": ("NOPE", None)})
             self.parser.merge_module_options()
 
-    def test_should_build_fail_to_validate_options(self):
+    def test_should_build_fail_to_validate_repo_options(self):
         # existant options with wrong input
-        with self.assertRaises(le.LbuildDumpConfigException):
+        with self.assertRaises(le.LbuildParserOptionInvalidException):
             self._get_build_modules({"repo1:target": ("NOPE", None)})
-        with self.assertRaises(le.LbuildDumpConfigException):
+
+    def test_should_build_fail_to_validate_module_options(self):
+        # existant options with wrong input
+        with self.assertRaises(le.LbuildParserOptionInvalidException):
             self._get_build_modules({"repo1:other:xyz": ("NOPE", None)})
             self.parser.merge_module_options()
 

--- a/test/resources/parser/combined/repo1/other.lb
+++ b/test/resources/parser/combined/repo1/other.lb
@@ -13,8 +13,11 @@ def prepare(module, options):
 	module.add_option(NumericOption(name="bar", default=12, description="A second option"))
 	module.add_option(BooleanOption(name="xyz", default=False, description="Bla"))
 	module.add_option(StringOption(name="abc", description="Blub"))
+
+	module.add_collector(StringCollector(name="cllctr", description="Blub"))
 	return True
 
 def build(env):
 	env.copy('other/src', 'src')
 	env.copy('other/test', 'test')
+	env.collect("cllctr", "world")

--- a/test/resources/parser/combined/test1.xml
+++ b/test/resources/parser/combined/test1.xml
@@ -20,6 +20,11 @@
 		<option name="::submodule3::price">15</option>
 	</options>
 
+	<collectors>
+		<collect name="::cllctr">hello</collect>
+		<collect name="::cllctr">wallaby</collect>
+	</collectors>
+
 	<modules>
 		<module>repo1:other</module>
 		<module>:module1</module>


### PR DESCRIPTION
This adds the ability to collect values in the project configuration instead of just in modules.
This allows to add collector values directly, instead of via a custom (empty) module or by adding a custom option which then adds this to a collector in the build step.

```xml
<collectors>
  <collect name="module:key">value</collect>
  <collect name="module:key">value2</collect>
</collectors>
```

cc @dergraaf 