### PR TITLE
Remove dependency on colorful package

### DIFF
--- a/lbuild/format.py
+++ b/lbuild/format.py
@@ -12,7 +12,6 @@ import os
 import sys
 import shutil
 import anytree
-import colorful
 
 import lbuild.node
 import lbuild.filter
@@ -37,7 +36,7 @@ COLOR_SCHEME = {
     "module": None,
     "description": None,
     "short_description": None,
-    "error": colorful.red,  # pylint: disable=no-member
+    "error": "\033[38;2;255;0;0m",
 }
 
 
@@ -46,16 +45,22 @@ def ansi_escape(obj=None):
         # The terminal does not support color
         return ""
 
+    COLORFUL_REPLACEMENT = {
+        "reset": "\033[0m",
+        "bold": "\033[1m",
+        "underlined": "\033[4m",
+        "no_bold": "\033[21m",
+        "no_underlined": "\033[24m",
+        "close_fg_color": "\033[39m",
+    }
+
     name = obj
     if isinstance(obj, lbuild.node.BaseNode):
         name = obj.type.name.lower()
 
     col = COLOR_SCHEME.get(name, "nope")
     if col == "nope":
-        try:
-            col = getattr(colorful, name)
-        except AttributeError:
-            col = None
+        col = COLORFUL_REPLACEMENT.get(name, None)
 
     return str(col) if col is not None else ""
 

--- a/lbuild/main.py
+++ b/lbuild/main.py
@@ -22,7 +22,7 @@ from lbuild.format import format_option_short_description
 
 from lbuild.api import Builder
 
-__version__ = '1.12.2'
+__version__ = '1.12.3'
 
 
 class InitAction:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,6 @@
 lxml
 jinja2
-anytree>=2.4.3
-colorful==0.4.4
+anytree>=2.6.0
 
 # Required for the tests
 testfixtures

--- a/setup.py
+++ b/setup.py
@@ -34,8 +34,7 @@ setup(
     install_requires = ["lxml",
                         "jinja2",
                         "gitpython>=2.1.11",
-                        "anytree>=2.4.3",
-                        "colorful==0.4.4"],
+                        "anytree>=2.6.0"],
 
     extras_require = {
         "test": ["testfixtures", "coverage"],


### PR DESCRIPTION
The colorful package is barely used and is a point of annoyance. This just replaces the package with using the ANSI escape code directly.

cc @strongly-typed 