### PR TITLE
Add option to symlink instead of copy

### DIFF
--- a/lbuild/api.py
+++ b/lbuild/api.py
@@ -121,7 +121,7 @@ class Builder:
         self.parser.validate_modules(build_modules, complete)
         return (build_modules, CallCounter.levels)
 
-    def build(self, outpath, modules=None, simulate=False):
+    def build(self, outpath, modules=None, simulate=False, use_symlinks=False):
         """
         Build the given set of modules.
 
@@ -135,5 +135,6 @@ class Builder:
         """
         build_modules = self._filter_modules(modules)
         buildlog = BuildLog(outpath)
+        lbuild.environment.SYMLINK_ON_COPY = use_symlinks
         self.parser.build_modules(build_modules, buildlog, simulate=simulate)
         return buildlog

--- a/lbuild/main.py
+++ b/lbuild/main.py
@@ -22,7 +22,7 @@ from lbuild.format import format_option_short_description
 
 from lbuild.api import Builder
 
-__version__ = '1.12.4'
+__version__ = '1.12.5'
 
 
 class InitAction:
@@ -297,6 +297,13 @@ class BuildAction(ManipulationActionBase):
             default=False,
             help="Build, but do not write any files. Prints out all generated file names.")
         parser.add_argument(
+            "--symlink",
+            dest="symlink",
+            action="store_true",
+            default=False,
+            help="Use symlinks for file copies. Generated files cannot be "
+                 "copied, so be CAREFUL what files you edit!")
+        parser.add_argument(
             "--no-log",
             dest="buildlog",
             action="store_false",
@@ -308,7 +315,8 @@ class BuildAction(ManipulationActionBase):
 
     @staticmethod
     def perform(args, builder):
-        buildlog = builder.build(args.path, args.modules, simulate=args.simulate)
+        buildlog = builder.build(args.path, args.modules, simulate=args.simulate,
+                                 use_symlinks=args.symlink)
 
         if args.simulate:
             ostream = []


### PR DESCRIPTION
This adds the option to `lbuild build --symlink` which creates symbolic links to the source file (in the respective repositories) instead of creating copies of them.

This makes it easier for library developers to change source files inside their project (with working IDE, source code completetion etc), instead of switching to a generic editor without those niceties only for editing the module files.

Fixed #45. cc @ASMfreaK 