### PR TITLE
Allow declaring build order within subtrees

### DIFF
--- a/lbuild/facade.py
+++ b/lbuild/facade.py
@@ -187,6 +187,14 @@ class ModuleInitFacade(BaseNodeInitFacade):
                    "module.name = \":parent:module\"")
         self._node.parent = name
 
+    @property
+    def order(self):
+        return self._node.order
+
+    @order.setter
+    def order(self, number):
+        self._node.order = number
+
     def add_filter(self, name, function):
         self._node._filters.append( (name, function,) )
 

--- a/lbuild/main.py
+++ b/lbuild/main.py
@@ -22,7 +22,7 @@ from lbuild.format import format_option_short_description
 
 from lbuild.api import Builder
 
-__version__ = '1.12.5'
+__version__ = '1.13.0'
 
 
 class InitAction:

--- a/lbuild/module.py
+++ b/lbuild/module.py
@@ -102,6 +102,7 @@ class ModuleInit:
         self.description = ""
         self.functions = {}
         self.available = False
+        self.order = 0
         self._format_description = lbuild.format.format_description
         self._format_short_description = lbuild.format.format_short_description
 
@@ -143,6 +144,8 @@ class ModuleInit:
 
         self.parent = ":".join(p.strip(":") for p in (self.repository.name,
                                 parent_parent, parent_name, name_parent) if p)
+
+        self.order = int(self.order)
 
     def prepare(self):
         self.available = lbuild.utils.with_forward_exception(
@@ -187,6 +190,7 @@ class Module(BaseNode):
         self._description = module.description
         self._fullname = module.fullname
         self._available = module.available
+        self._build_order = module.order
 
         # Prefix the global filters with the `repo.` name
         for (name, func) in module._filters:

--- a/lbuild/node.py
+++ b/lbuild/node.py
@@ -201,6 +201,7 @@ class BaseNode(anytree.Node):
         self._dependencies_resolved = False
         self._dependencies = []
 
+        self._build_order = 0
         self._description = ""
         # All _update()-able traits: defaults
         self._available_default = True
@@ -472,6 +473,17 @@ class BaseNode(anytree.Node):
 
         for child in self.children:
             child._update_format()
+
+    def _update_order(self):
+        if self.parent:
+            # Set every module order in tree to sum of subtree
+            if self.type is self.Type.MODULE and self.parent.type is self.Type.REPOSITORY:
+                self._build_order = sum(d._build_order for d in (self.descendants + (self,)) if d._selected)
+            elif self.parent._build_order:
+                self._build_order = self.parent._build_order
+
+        for child in self.children:
+            child._update_order()
 
     def _update(self):
         if self.parent:

--- a/lbuild/repository.py
+++ b/lbuild/repository.py
@@ -10,6 +10,7 @@
 # governing this code.
 
 import os
+import sys
 import glob
 import logging
 import fnmatch
@@ -89,6 +90,7 @@ class Repository(BaseNode):
         self._functions = repo._functions
         self._format_description = repo._format_description
         self._format_short_description = repo._format_short_description
+        self._build_order = sys.maxsize
 
         if repo.name is None:
             raise le.LbuildRepositoryNoNameException(repo._parser, repo)


### PR DESCRIPTION
Some post-build steps actually need to be run last, because other post-build steps add things to the buildlog (🤦‍♂).

This still builds submodules before their parent modules, but the build is grouped into the top-level modules by the *sum* of all selected submodule tree orders (`0` being the neutral default).

Usage:
```py
def init(module):
    module.name = ":build"
    # build this subtree really, realllly last
    module.order = sys.maxsize
```

In modm this allows the `:build` submodule tree to always be run last.
```
...
[INFO] lbuild.module: Build modm:debug
[INFO] lbuild.module: Build modm:driver
[INFO] lbuild.module: Build modm:build:scons
[INFO] lbuild.module: Build modm:build
[INFO] lbuild.repository: Build modm
[INFO] lbuild.module: Post-Build modm:platform:core
[INFO] lbuild.module: Post-Build modm:docs
[INFO] lbuild.module: Post-Build modm:build:scons
[INFO] lbuild.module: Post-Build modm:build
```

@dergraaf How evil is this?
cc @nesos this will help with https://github.com/modm-io/modm/pull/307