### PR TITLE
Remove generated files before build and detect modified files

### DIFF
--- a/lbuild/environment.py
+++ b/lbuild/environment.py
@@ -44,6 +44,8 @@ def _copyfile(sourcepath, destpath, fn_copy=None):
     if fn_copy is None:
         fn_copy = default_fn_copy
     if not SIMULATE:
+        if not os.path.exists(os.path.dirname(destpath)):
+            os.makedirs(os.path.dirname(destpath), exist_ok=True)
         fn_copy(sourcepath, destpath)
 
 
@@ -76,8 +78,6 @@ def _copytree(logger, src, dst, ignore=None,
                 _copytree(logger, sourcepath, destpath, ignore, fn_listdir, fn_isdir, fn_copy)
             else:
                 starttime = time.time()
-                if not os.path.exists(dst):
-                    os.makedirs(dst, exist_ok=True)
                 _copyfile(sourcepath, destpath, fn_copy)
                 endtime = time.time()
                 total = endtime - starttime
@@ -176,8 +176,6 @@ class Environment:
                 _copytree(log_copy, src, destpath, wrap_ignore,
                           fn_listdir, fn_isdir, fn_copy)
             else:
-                if not os.path.exists(os.path.dirname(destpath)):
-                    os.makedirs(os.path.dirname(destpath), exist_ok=True)
                 _copyfile(src, destpath, fn_copy)
 
                 endtime = time.time()
@@ -227,8 +225,6 @@ class Environment:
                       destpath,
                       wrap_ignore)
         else:
-            if not os.path.exists(os.path.dirname(destpath)):
-                os.makedirs(os.path.dirname(destpath), exist_ok=True)
             _copyfile(srcpath, destpath)
 
             endtime = time.time()
@@ -284,11 +280,11 @@ class Environment:
 
         outfile_name = self.outpath(dest)
 
-        # Create folder structure if it doesn't exists
         if not SIMULATE:
+            # Create folder structure if it doesn't exists
             if not os.path.exists(os.path.dirname(outfile_name)):
                 os.makedirs(os.path.dirname(outfile_name), exist_ok=True)
-
+            # Write template output to file
             with open(outfile_name, 'w', encoding="utf-8") as outfile:
                 outfile.write(output)
 

--- a/lbuild/exception.py
+++ b/lbuild/exception.py
@@ -353,6 +353,21 @@ class LbuildBuildlogOverwritingFileException(LbuildException):
         super().__init__(msg)
 
 
+# =============================== API EXCEPTIONS ==============================
+class LbuildApiBuildlogNotFoundException(LbuildException):
+    def __init__(self, buildlog):
+        msg = "Buildlog '{}' not found!".format(_hl(_rel(buildlog)))
+        super().__init__(msg)
+        self.buildlog = buildlog
+
+class LbuildApiModifiedFilesException(LbuildException):
+    def __init__(self, buildlog, modified):
+        msg = ("Buildlog '{}' shows these generated files were modified:\n\n{}"
+               .format(_hl(_rel(buildlog)), _bp(_rel(m) for m in modified)))
+        super().__init__(msg)
+        self.buildlog = buildlog
+        self.modified = modified
+
 # =========================== REPOSITORY EXCEPTIONS ===========================
 class LbuildRepositoryNoNameException(LbuildDumpConfigException):
     def __init__(self, parser, repo): # RepositoryInit

--- a/lbuild/utils.py
+++ b/lbuild/utils.py
@@ -12,8 +12,10 @@
 import os
 import sys
 import uuid
+import time
 import shutil
 import fnmatch
+import hashlib
 import importlib.util
 import importlib.machinery
 
@@ -203,3 +205,13 @@ def _is_pathname_valid(pathname: str) -> bool:
     except TypeError as exc:
         return False
     return True
+
+def hash_file(filename):
+    if os.path.exists(filename):
+        with open(filename, "rb") as fileobj:
+            return (int(os.path.getmtime(filename)),
+                    hashlib.md5(fileobj.read().strip()).hexdigest())
+    return (None, None)
+
+def hash_content(content):
+    return (int(time.time()), hashlib.md5(file_or_content).hexdigest())

--- a/test/buildlog_test.py
+++ b/test/buildlog_test.py
@@ -65,14 +65,15 @@ class BuildLogTest(unittest.TestCase):
 
         self.assertEqual(b"""<?xml version='1.0' encoding='UTF-8'?>
 <buildlog>
+  <version>2.0</version>
   <outpath>.</outpath>
   <operation>
-    <module>repo:module1</module>
+    <module name="repo:module1"/>
     <source>m1/in1</source>
     <destination>out1</destination>
   </operation>
   <operation>
-    <module>repo:module2</module>
+    <module name="repo:module2"/>
     <source>m2/in2</source>
     <destination>out2</destination>
   </operation>


### PR DESCRIPTION
This enhances the `lbuild build` and `lbuild clean` commands to detect modified generated files *before* deletion, via modified timestamp comparison (and content hash as backup) in the buildlog. The commands fail if a modification is detected and users can `lbuild clean --force` to clear them by force.

TODO:
- [x] Implement content change detection in buildlog
- [x] Clean before building to remove files from previous configuration
- [ ] Testing

Fixes #33.

cc @dergraaf @WasabiFan