### PR TITLE
New uniquify filter and access to filters

### DIFF
--- a/lbuild/environment.py
+++ b/lbuild/environment.py
@@ -114,6 +114,10 @@ class Environment:
     def queries(self):
         return self.__module.query_resolver(self.facade)
 
+    @property
+    def filters(self):
+        return self.__module.filters
+
     def extract(self, archive_path, src=None, dest=None, ignore=None, metadata=None):
 
         def wrap_ignore(path, files):

--- a/lbuild/facade.py
+++ b/lbuild/facade.py
@@ -220,6 +220,12 @@ class EnvironmentValidateFacade:
     def has_collector(self, key):
         return key in self._env.collectors_available
 
+    def has_filter(self, key):
+        return key in self._env.filters
+
+    def filter(self, key, default=None):
+        return self._env.filters.get(key, default)
+
     def get(self, key, default=None):
         return self._env.options.get(key, default)
 

--- a/lbuild/filter.py
+++ b/lbuild/filter.py
@@ -62,5 +62,6 @@ DEFAULT_FILTERS = {
     'lbuild.pad': pad,
     'lbuild.values': values,
     'lbuild.split': split,
-    'lbuild.listify': listify,
+    'lbuild.listify': lbuild.utils.listify,
+    'lbuild.uniquify': lbuild.utils.uniquify
 }

--- a/lbuild/main.py
+++ b/lbuild/main.py
@@ -22,7 +22,7 @@ from lbuild.format import format_option_short_description
 
 from lbuild.api import Builder
 
-__version__ = '1.13.3'
+__version__ = '1.13.4'
 
 
 class InitAction:

--- a/lbuild/node.py
+++ b/lbuild/node.py
@@ -319,6 +319,10 @@ class BaseNode(anytree.Node):
     def module_resolver(self):
         return NameResolver(self, self.Type.MODULE)
 
+    @property
+    def filters(self):
+        return self._filters
+
     def render(self, filterfunc=None):
         return lbuild.format.format_node_tree(self, filterfunc)
 

--- a/lbuild/node.py
+++ b/lbuild/node.py
@@ -37,6 +37,7 @@ def load_functions_from_file(repository, filename: str, required, optional=None,
         'repopath': RelocatePath(repository._filepath),
         'listify': lu.listify,
         'listrify': lu.listrify,
+        'uniquify': lu.uniquify,
 
         'FileReader': LocalFileReaderFactory(localpath),
         'ValidateException': le.LbuildValidateException,

--- a/lbuild/utils.py
+++ b/lbuild/utils.py
@@ -92,6 +92,13 @@ def listrify(*objs):
     return list(map(str, listify(*objs)))
 
 
+def uniquify(*objs, key=None):
+    """
+    Return a list of unique objects, sorted by key.
+    """
+    return list(sorted(set(*objs), key=key))
+
+
 def get_global_functions(env, required, optional=None):
     """
     Get global functions an environment.


### PR DESCRIPTION
Allows accessing shared filters in modules, so you can use user-added filters not only in jinja2 templates.

A new uniquify filter is added for convenience.