### PR TITLE
Print full forward exception traceback

### DIFF
--- a/lbuild/exception.py
+++ b/lbuild/exception.py
@@ -88,8 +88,11 @@ class LbuildDumpConfigException(LbuildException):
 class LbuildForwardException(LbuildException):
     def __init__(self, location, error):
         import traceback
-        error_fmt = "".join(traceback.format_exception(type(error), error,
-                                                       error.__traceback__, limit=-1))
+        tb = error.__traceback__
+        limit = -next((i for i, fs in enumerate(reversed(traceback.extract_tb(tb)))
+                       if os.path.dirname(__file__) in fs.filename), 0)
+
+        error_fmt = "".join(traceback.format_exception(type(error), error, tb, limit=limit))
         error_fmt = error_fmt.replace("lbuild.exception.Lbuild", "")
         msg = ("In '{}':\n\n{}"
                .format(_hl(location), _hl(error_fmt)))

--- a/lbuild/main.py
+++ b/lbuild/main.py
@@ -22,7 +22,7 @@ from lbuild.format import format_option_short_description
 
 from lbuild.api import Builder
 
-__version__ = '1.13.4'
+__version__ = '1.13.5'
 
 
 class InitAction:
@@ -543,7 +543,7 @@ def main():
 
     except lbuild.exception.LbuildException as error:
         sys.stderr.write('\nERROR: {}\n'.format(error))
-        if args.verbose >= 2:
+        if args.verbose >= 1:
             traceback.print_exc()
         sys.exit(1)
 

--- a/lbuild/node.py
+++ b/lbuild/node.py
@@ -279,11 +279,13 @@ class BaseNode(anytree.Node):
 
     @property
     def description(self):
-        return self._format_description(self, str(self._description))
+        return lu.with_forward_exception(self.fullname,
+                lambda: self._format_description(self, str(self._description)))
 
     @property
     def short_description(self):
-        return self._format_short_description(self, str(self._description))
+        return lu.with_forward_exception(self.fullname,
+                lambda: self._format_short_description(self, str(self._description)))
 
     @description.setter
     def description(self, description):


### PR DESCRIPTION
This fixes the underlying issue of #55, where the LbuildForwardException only printed the very last stacktrace entry, which is not useful when the error occurs more than one layer deep.

This PR limits the summary traceback to everything outside of lbuild, and prints full tracebacks on just one `-v` flag instead of two.

cc @rleh 