### PR TITLE
[option] Add non-unique input option list

### DIFF
--- a/README.md
+++ b/README.md
@@ -651,16 +651,16 @@ def build(env):
     value = env[":module:option"]
 ```
 
-If your option requires a set of input values, you can tell *lbuild* to wrap the
-option into a set using `module.add_set_option()`:
+If your option requires a unique set of input values, you can tell *lbuild* to 
+wrap the option into a set using `module.add_set_option()`:
 
 ```python
 def prepare(module, options):
-    # Add an option, but allow a set of values as input and output
+    # Add an option, but allow a set of unique values as input and output
     module.add_set_option(option)
 
 def build(env):
-    # a list of option values is returned here
+    # a unique set of option values is returned here
     for value in env[":module:option"]:
         print(value)
 ```
@@ -673,6 +673,19 @@ easy to split your string value in Python exactly how you want.
 ```xml
 <!-- All comma separated values are validated by the option -->
 <option name=":module:set-option">value, 1, obj</option>
+```
+
+If you want to preserve duplicates to count the number of inputs, use a list
+option `module.add_list_option()`:
+
+```python
+def prepare(module, options):
+    # Add an option, but allow a list of values as input and output
+    module.add_list_option(option)
+
+def build(env):
+    # a list of option values is returned here
+    value_count = env[":module:option"].count("value")
 ```
 
 Options can have a dependency handler which is called when the project

--- a/lbuild/facade.py
+++ b/lbuild/facade.py
@@ -104,6 +104,9 @@ class RepositoryInitFacade(BaseNodeInitFacade):
     def add_set_option(self, option, default=None):
         self._node._options.append(OptionSet(option, default))
 
+    def add_list_option(self, option, default=None):
+        self._node._options.append(OptionSet(option, default, unique=False))
+
     def add_query(self, query):
         self._node._queries.append(query)
 
@@ -154,6 +157,9 @@ class ModulePrepareFacade(BaseNodePrepareFacade):
 
     def add_set_option(self, option, default=None):
         self._node._options.append(OptionSet(option, default))
+
+    def add_list_option(self, option, default=None):
+        self._node._options.append(OptionSet(option, default, unique=False))
 
     def add_query(self, query):
         self._node._queries.append(query)

--- a/lbuild/main.py
+++ b/lbuild/main.py
@@ -22,7 +22,7 @@ from lbuild.format import format_option_short_description
 
 from lbuild.api import Builder
 
-__version__ = '1.13.5'
+__version__ = '1.14.0'
 
 
 class InitAction:

--- a/test/option_test.py
+++ b/test/option_test.py
@@ -285,6 +285,8 @@ class OptionTest(unittest.TestCase):
                     EnumerationOption("test", "description", enumeration=enum_dict),
                     default=["value1", "value2"])
         self.assertEqual([1, 2], option.value)
+        self.assertIn("{value1, value2}",
+                      str(lbuild.format.format_option_value_description(option)))
 
         with self.assertRaises(le.LbuildOptionInputException):
             option.value = {1, 2}
@@ -311,6 +313,8 @@ class OptionTest(unittest.TestCase):
         option = OptionSet(
                     EnumerationOption("test", "description", enumeration=enum_list),
                     default=["value1", "value2"])
+        self.assertIn("{value1, value2}",
+                      str(lbuild.format.format_option_value_description(option)))
         self.assertEqual(["value1", "value2"], option.value)
         with self.assertRaises(le.LbuildOptionInputException):
             option.value = {"value3"}
@@ -324,6 +328,15 @@ class OptionTest(unittest.TestCase):
                     EnumerationOption("test", "description", enumeration=enum_list),
                     default=["value1", "value1"])
         self.assertEqual(["value1"], option.value)
+        self.assertIn("{value1}",
+                      str(lbuild.format.format_option_value_description(option)))
+
+        option1 = OptionSet(
+                    EnumerationOption("test", "description", enumeration=enum_list),
+                    default=["value1", "value1"], unique=False)
+        self.assertEqual(["value1", "value1"], option1.value)
+        self.assertIn("[value1, value1]",
+                      str(lbuild.format.format_option_value_description(option1)))
 
     def test_should_be_constructable_from_range(self):
         option = EnumerationOption("test", "description",
@@ -336,6 +349,8 @@ class OptionTest(unittest.TestCase):
                     EnumerationOption("test", "description", enumeration=range(1, 21)),
                     default=range(5, 9))
         self.assertEqual([5, 6, 7, 8], option.value)
+        self.assertIn("{5, 6, 7, 8}",
+                      str(lbuild.format.format_option_value_description(option)))
 
     def test_should_be_constructable_from_set(self):
         option = EnumerationOption("test", "description",
@@ -348,6 +363,8 @@ class OptionTest(unittest.TestCase):
                     EnumerationOption("test", "description", enumeration=set(range(1, 21))),
                     default=set(range(5, 9)))
         self.assertEqual({5, 6, 7, 8}, set(option.value))
+        self.assertIn("{5, 6, 7, 8}",
+                      str(lbuild.format.format_option_value_description(option)))
 
     def test_should_format_boolean_option(self):
         option = BooleanOption("test", "description", default=True)
@@ -388,17 +405,17 @@ class OptionTest(unittest.TestCase):
         output = str(lbuild.format.format_option_value_description(option))
         self.assertIn("value1 in [value1, value2]", output, "Output")
 
-    def test_should_format_enumeration_option_set(self):
+    def test_should_format_enumeration_option_set_empty(self):
         enum_list = [
             "value1",
             "value2",
         ]
         option = OptionSet(
-                    EnumerationOption("test", "description", enumeration=enum_list),
-                    default=["value1", "value2"])
+                    EnumerationOption("test", "description", enumeration=enum_list))
 
-        output = str(lbuild.format.format_option_value_description(option))
-        self.assertIn("{value1, value2} in [value1, value2]", output)
+        self.assertEqual([], option.value)
+        self.assertIn("{} in [value1, value2]",
+                      str(lbuild.format.format_option_value_description(option)))
 
     def test_should_format_enumeration_option_without_default_value(self):
         enum_list = [


### PR DESCRIPTION
This fixes an bug with empty default of set options and adds a simple `module.add_list_option` that preserves duplicates in inputs. That's all.