### PR TITLE
Feature: Env var substitution in project configuration file

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,7 +240,8 @@ which *lbuild* will search for in the current working directory.
   <repositories>
     <!-- Declare all your repository locations relative to this file here -->
     <repository><path>path/to/repo.lb</path></repository>
-    <repository><path>path/to/repo2.lb</path></repository>
+    <!-- You can also use environment variables in all nodes -->
+    <repository><path>${PROJECTHOME}/repo2.lb</path></repository>
   </repositories>
   <!-- You can also inherit from another configfile. The options you specify
        here will be overwritten. -->

--- a/lbuild/exception.py
+++ b/lbuild/exception.py
@@ -108,6 +108,15 @@ class LbuildConfigException(LbuildException):
         super().__init__(message)
         self.filename = filename
 
+class LbuildConfigSubstitutionException(LbuildConfigException):
+    def __init__(self, filename, node, key):
+        filename = _rel(filename)
+        message = (": Unable to resolve '${{{}}}'!\n\n"
+            "    {}\n\n"
+            "Hint: Check if the variable exists in your shell environment.\n"
+            .format(_hl(key), node.strip()))
+        super().__init__(filename, message)
+
 class LbuildConfigNotFoundException(LbuildConfigException):
     def __init__(self, filename, parent=None):
         filename = _rel(filename)

--- a/lbuild/main.py
+++ b/lbuild/main.py
@@ -22,7 +22,7 @@ from lbuild.format import format_option_short_description
 
 from lbuild.api import Builder
 
-__version__ = '1.14.1'
+__version__ = '1.15.0'
 
 
 class InitAction:

--- a/test/config_test.py
+++ b/test/config_test.py
@@ -67,8 +67,16 @@ class ConfigTest(unittest.TestCase):
         with self.assertRaises(le.LbuildConfigNotFoundException):
             config = self._parse_config("non-existant.xml")
 
+        with self.assertRaises(le.LbuildConfigSubstitutionException):
+            config = self._parse_config("configfile/project.xml")
+
+        os.environ["LBUILD_TEST_REPOHOME"] = self._get_path("repo2")
         config = self._parse_config("configfile/project.xml")
+        del os.environ["LBUILD_TEST_REPOHOME"]
         self.assertEqual(self._get_path("configfile/hello_there"), abspath(config.cachefolder))
+
+        self.assertEqual(2, len(config.repositories))
+        self.assertIn(self._get_path("repo2/repo2.lb"), config.repositories)
 
         modules = config.modules
         self.assertEqual(4, len(modules))

--- a/test/resources/config/configfile/project.xml
+++ b/test/resources/config/configfile/project.xml
@@ -5,7 +5,7 @@
 			<path>repo1.lb</path>
 		</repository>
 		<repository>
-			<path>repo2/repo2.lb</path>
+			<path>${LBUILD_TEST_REPOHOME}/repo2.lb</path>
 		</repository>
 		<cache>hello_there/</cache>
 	</repositories>


### PR DESCRIPTION

Hi,
this PR is a follow up to modm-io/modm#561

## Why should this be a thing
 
 * I started compiling and structuring my projects in some random directory (/home/myusername/whatever) instead of the examples directory inside of modm
 * When doing that, the repository tag is needed in the project xml, so that the repo.ld can be found (could probably be given as an input arg but I am lazy) 
 * relative paths suck when doing something like this, 
 * also when doing automation, env arguments for generic scripts / configurations are wonderful

## What should work:

* consider a project.xml, where the repository path is added and should be substituted by the env variable `HOME`

```xml
<library>
  <repositories>
    <repository>
      <path>${HOME}/gitclones/modm/repo.lb</path>
    </repository>
  </repositories>

  <extends>modm:nucleo-f767zi</extends>
  <options>
    <option name="modm:build:build.path">build/nucleo_f767zi/ethernet</option>
  </options>
  <modules>
    <module>modm:build:scons</module>
    <module>modm:freertos:tcp:lan8720a</module>
    <module>modm:processing:rtos</module>
  </modules>
</library>
```

## Why does it not work

* The xml parser used cannot do it properly. Therefore a small hack has to be introduced

## What did I do

 * added a small recursive text substitution for every node text from a global lookup dictionary 
     * which is default filled with `os.environ` dict, but coud also be used for other lookup values as well

## how does it look

* after doing `xmltree = ConfigNode._load_and_verify(configfile)` [config.py]
* we also do `xmltree = ConfigNode._substitute_env(xmltree, env=os.environ)`
    * which returns the same xmltree, but with all `${VAR_NAME}` texts substituded by the corresponding env variable

