### PR TITLE
Add Alias node for deprecating tree changes gracefully

### DIFF
--- a/README.md
+++ b/README.md
@@ -1057,6 +1057,47 @@ collector = EnumerationCollector(name="collector-name",
 ```
 
 
+### Aliases
+
+*lbuild* aliases are mappings from one lbuild node to another. They are useful
+for gracefully dealing with renaming or moving nodes in your lbuild module tree.
+Aliases will print a warning when accessed showing the alias description. Each
+alias must have a unique name within their parent repository or module.
+
+Aliases can be used for any type of node that you want forwarded. You can also
+add aliases that do not have a destination and will raise an exception with the
+alias description. This allows you to remove lbuild nodes while providing
+details for a workaround.
+
+```python
+def prepare(module, options):
+    # Move option in this module
+    module.add_module(Option(name="option"))
+    # Forward the old option to the new option
+    module.add_alias(Alias(name="option-alias",
+                           destination="option",
+                           description="Renamed for clarity."))
+    # Instead of silently failing, you can provide a detailed description
+    # about why the node was removed and what the workaround is.
+    module.add_alias(Alias(name="removed-alias",
+                           description="Removed. Workaround: ..."))
+    # You alias any type to any other node.
+    module.add_alias(Alias(name="submodule-alias",
+                           destination=":other-module:submodule"
+                           description="Removed. Workaround: ..."))
+
+def build(env):
+    # Will show a warning (once) that the alias has been moved
+    exists = env.has_option(":module:option-alias")
+    # Accesses :module:option instead
+    value = env[":module:option-alias"]
+    # This will raise an exception with the alias description
+    value = env[":module:removed-alias"]
+    # will check for :other-module:submodule instead
+    value = env.has_module[":module:submodule-alias"]
+```
+
+
 ### Jinja2 Configuration
 
 *lbuild* uses the [Jinja2 template engine][jinja2] with the following global

--- a/lbuild/exception.py
+++ b/lbuild/exception.py
@@ -471,6 +471,12 @@ class LbuildResolverAmbiguousMatchException(LbuildResolverException):
         self.query = query
         self.results = results
 
+class LbuildResolverAliasException(LbuildResolverException):
+    def __init__(self, node):
+        msg = ("Cannot resolve alias of '{}'!\n\n{}\n\n{}"
+               .format(_hl(node.fullname), node.description, _call_site()))
+        super().__init__(msg, node)
+        self.query = node.fullname
 
 # =========================== ENVIRONMENT EXCEPTIONS ==========================
 class LbuildEnvironmentException(LbuildException):

--- a/lbuild/facade.py
+++ b/lbuild/facade.py
@@ -119,6 +119,9 @@ class RepositoryInitFacade(BaseNodeInitFacade):
     def add_configuration(self, name, path, description=None):
         self._node._configurations.append( (name, path, description,) )
 
+    def add_alias(self, alias):
+        self._node._alias.append(alias)
+
 
 class RepositoryPrepareFacade(BaseNodePrepareFacade):
 
@@ -166,6 +169,9 @@ class ModulePrepareFacade(BaseNodePrepareFacade):
 
     def add_collector(self, collector):
         self._node._collectors.append(collector)
+
+    def add_alias(self, alias):
+        self._node._alias.append(alias)
 
     def add_modules(self, *modules):
         self._node._submodules.extend(modules)

--- a/lbuild/format.py
+++ b/lbuild/format.py
@@ -213,6 +213,9 @@ def format_description(node, description):
     elif node.type == node.Type.COLLECTOR:
         values = format_option_values(node, offset=9, single_line=False)
         output += [_cw(""), _cw("Inputs: [") + values + _cw("]")]
+    elif node.type == node.Type.ALIAS:
+        alias = _cw("Removed" if node._destination is None else node._destination).wrap("bold")
+        output += [_cw(""), _cw("Alias: ") + alias]
 
     children = []
     # Print every node except the submodule, due to obvious recursion
@@ -242,7 +245,7 @@ def format_node(node, _, depth):
         name = format_option_name(node, fullname=False)
     elif node._type in {node.Type.MODULE, node.Type.CONFIG}:
         name = _cw(node.fullname).wrap(node)
-    elif node._type in {node.Type.QUERY, node.Type.COLLECTOR}:
+    elif node._type in {node.Type.QUERY, node.Type.COLLECTOR, node.Type.ALIAS}:
         name = name.wrap("bold")
     if node._type in {node.Type.MODULE} and node._selected:
         name = name.wrap("underlined")
@@ -257,6 +260,9 @@ def format_node(node, _, depth):
         descr += _cw(" in [")
         descr += format_option_values(node, offset=offset + len(descr), single_line=True)
         descr += _cw("]")
+    elif node._type == node.Type.ALIAS:
+        descr += _cw(" -> ")
+        descr += _cw("Removed" if node._destination is None else node._destination).wrap("bold")
 
     descr += _cw("   " + node.short_description)
 

--- a/lbuild/main.py
+++ b/lbuild/main.py
@@ -22,7 +22,7 @@ from lbuild.format import format_option_short_description
 
 from lbuild.api import Builder
 
-__version__ = '1.15.0'
+__version__ = '1.16.0'
 
 
 class InitAction:

--- a/lbuild/module.py
+++ b/lbuild/module.py
@@ -112,6 +112,7 @@ class ModuleInit:
         self._filters = []
         self._queries = []
         self._collectors = []
+        self._alias = []
 
     @property
     def fullname(self):
@@ -202,7 +203,7 @@ class Module(BaseNode):
             self._filters[name] = func
 
         try:
-            for child in (module._options + module._queries):
+            for child in (module._options + module._queries + module._alias):
                 self.add_child(child)
             for collector in module._collectors:
                 self.add_child(lbuild.collector.Collector(collector))

--- a/lbuild/repository.py
+++ b/lbuild/repository.py
@@ -64,6 +64,7 @@ class RepositoryInit:
         self._queries = []
         self._ignore_patterns = []
         self._configurations = []
+        self._alias = []
 
     def init(self):
         lbuild.utils.with_forward_exception(self,


### PR DESCRIPTION
I recently moved some options to a different module, but their behavior is the same, so I wanted a way to just alias them over and give the user a warning. Otherwise the option just disappears and the user has to figure out what happened where.

In addition there are also aliases that can point to nothing, which will trigger an exception that shows the alias description. This is useful for documentating breaking changes in the module tree.

- [x] Implemented
- [x] Tested incl. Unittests
- [x] Documentation

