### PR TITLE
Fix missing repo alias and missing options on lbuild discover

### DIFF
--- a/lbuild/exception.py
+++ b/lbuild/exception.py
@@ -173,7 +173,7 @@ class LbuildConfigAddNotFoundException(LbuildConfigException):
 
 class LbuildConfigAliasNotFoundException(LbuildConfigException):
     def __init__(self, parser, alias):
-        message = (": alias '{}' not found in any repository!"
+        message = (": name '{}' not found in any repository!"
                    .format(_hl(alias)) + _dump(parser))
         filename = next( (f for f, a in parser._config_flat._extends.items() if alias in a), None)
         super().__init__(filename, message)
@@ -181,7 +181,7 @@ class LbuildConfigAliasNotFoundException(LbuildConfigException):
 class LbuildConfigAliasAmbiguousException(LbuildConfigException):
     def __init__(self, parser, alias, matches):
         aliases = _bp(sorted(c.fullname for c in matches))
-        message = (": alias '{}' is ambiguous!\n"
+        message = (": name '{}' is ambiguous!\n"
                    "Hint: Found multiple matches:\n\n{}"
                    .format(_hl(alias), aliases) + _dump(parser))
         filename = next( (f for f, a in parser._config_flat._extends.items() if alias in a), None)

--- a/lbuild/format.py
+++ b/lbuild/format.py
@@ -215,7 +215,7 @@ def format_description(node, description):
         output += [_cw(""), _cw("Inputs: [") + values + _cw("]")]
     elif node.type == node.Type.ALIAS:
         alias = _cw("Removed" if node._destination is None else node._destination).wrap("bold")
-        output += [_cw(""), _cw("Alias: ") + alias]
+        output += [_cw(""), _cw("Destination: ") + alias]
 
     children = []
     # Print every node except the submodule, due to obvious recursion
@@ -245,7 +245,7 @@ def format_node(node, _, depth):
         name = format_option_name(node, fullname=False)
     elif node._type in {node.Type.MODULE, node.Type.CONFIG}:
         name = _cw(node.fullname).wrap(node)
-    elif node._type in {node.Type.QUERY, node.Type.COLLECTOR, node.Type.ALIAS}:
+    elif node._type in {node.Type.QUERY, node.Type.COLLECTOR}:
         name = name.wrap("bold")
     if node._type in {node.Type.MODULE} and node._selected:
         name = name.wrap("underlined")
@@ -262,7 +262,7 @@ def format_node(node, _, depth):
         descr += _cw("]")
     elif node._type == node.Type.ALIAS:
         descr += _cw(" -> ")
-        descr += _cw("Removed" if node._destination is None else node._destination).wrap("bold")
+        descr += _cw("Removed" if node._destination is None else node._destination)
 
     descr += _cw("   " + node.short_description)
 

--- a/lbuild/main.py
+++ b/lbuild/main.py
@@ -22,7 +22,7 @@ from lbuild.format import format_option_short_description
 
 from lbuild.api import Builder
 
-__version__ = '1.16.0'
+__version__ = '1.16.1'
 
 
 class InitAction:
@@ -112,10 +112,10 @@ class DiscoverAction(ManipulationActionBase):
 
     @staticmethod
     def perform(args, builder):
-        builder._filter_modules()
+        names = args.names + args.names_explicit
+        builder._filter_modules(names)
         if args.show_developer_view:
             lbuild.format.SHOW_NODES.update(lbuild.node.BaseNode.Type)
-        names = args.names + args.names_explicit
         if names:
             ostream = []
             for node in builder.parser.find_all(names):

--- a/lbuild/node.py
+++ b/lbuild/node.py
@@ -128,7 +128,7 @@ class NameResolver:
             context_resolver = NameResolver(node.parent, self._type, self._selected, self._returner, self._defaulter)
             alias = node
             warning = "Node '{}' has been moved to '{}'!\n\n{}\n\n".format(
-                            alias.fullname, alias._destination, alias.description)
+                    le._hl(alias.fullname), le._hl(alias._destination), alias.description)
             try:
                 node = context_resolver._get_node(node._destination)
                 warning += node.description + "\n"
@@ -340,6 +340,10 @@ class BaseNode(anytree.Node):
     @property
     def module_resolver(self):
         return NameResolver(self, self.Type.MODULE)
+
+    @property
+    def config_resolver(self):
+        return NameResolver(self, self.Type.CONFIG)
 
     @property
     def filters(self):

--- a/lbuild/repository.py
+++ b/lbuild/repository.py
@@ -107,7 +107,7 @@ class Repository(BaseNode):
             self._filters[name] = func
 
         try:
-            for child in (repo._options + repo._queries):
+            for child in (repo._options + repo._queries + repo._alias):
                 self.add_child(child)
             for (name, path, description) in repo._configurations:
                 path = self._relocate_relative_path(path)

--- a/test/resolver_test.py
+++ b/test/resolver_test.py
@@ -38,6 +38,7 @@ class ResolverTest(unittest.TestCase):
 
         self.repo.add_child(Option("target", "", default="hosted"))
         self.repo.add_child(NumericOption("foo", "", default=43))
+        self.repo.add_child(Alias("alias0", "", destination="foo"))
 
         self.module.add_child(NumericOption("foo", "", default=456))
         self.module.add_child(NumericOption("bar", "", default=768))
@@ -93,6 +94,9 @@ class ResolverTest(unittest.TestCase):
 
     def test_should_resolve_alias(self):
         logging.disable(logging.WARNING)
+
+        resolver = self.repo.option_value_resolver
+        self.assertEqual(43, resolver[":alias0"])
 
         # Resolve Option aliases
         resolver = self.module.option_value_resolver


### PR DESCRIPTION
- Forgot to add the alias type to the repository node.
- Using a name resolver for configurations for aliasing
- Fixed lbuild discover description missing children descriptions if no module was selected (ie. without config)