### PR TITLE
lbuild pathing extensions for better lbuild --path handling

### DIFF
--- a/lbuild/buildlog.py
+++ b/lbuild/buildlog.py
@@ -77,9 +77,10 @@ class BuildLog:
     a specific file.
     """
 
-    def __init__(self, outpath=None):
+    def __init__(self, outpath=None, cwd=None):
         self._operations = collections.defaultdict(list)
         self._metadata = collections.defaultdict(lambda: collections.defaultdict(set))
+        self.cwd = os.getcwd() if cwd is None else abspath(cwd)
         self.outpath = os.getcwd() if outpath is None else abspath(outpath)
 
         self._build_files = {}

--- a/lbuild/config.py
+++ b/lbuild/config.py
@@ -32,6 +32,7 @@ class ConfigNode(anytree.AnyNode):
     def __init__(self, parent=None):
         anytree.AnyNode.__init__(self, parent)
 
+        self._outpath = None
         self._cachefolder = None
         self._extends = collections.defaultdict(list)
         self._vcs = []
@@ -63,6 +64,10 @@ class ConfigNode(anytree.AnyNode):
         return self._vcs
 
     @property
+    def outpath(self):
+        return self._outpath
+
+    @property
     def cachefolder(self):
         if self._cachefolder is None:
             return str(Path(self.filename).parent / DEFAULT_CACHE_FOLDER)
@@ -82,6 +87,8 @@ class ConfigNode(anytree.AnyNode):
         for node in list(self.siblings) + [self]:
             if node._cachefolder is not None:
                 config._cachefolder = node._cachefolder
+            if node._outpath is not None:
+                config._outpath = node._outpath
             config._extends.update(node._extends)
             config._vcs.extend(node._vcs)
             config._repositories.extend(node._repositories)
@@ -217,6 +224,11 @@ class ConfigNode(anytree.AnyNode):
 
         # Load all requested modules
         config._modules = xmltree.xpath('modules/module/text()')
+
+        # Load output path for lbuild and modules
+        outpath = xmltree.find("outpath")
+        if outpath is not None:
+            config._outpath = ConfigNode._rel_path(outpath.text, configpath)
 
         # Load options
         for option_node in xmltree.xpath('options/option'):

--- a/lbuild/environment.py
+++ b/lbuild/environment.py
@@ -94,7 +94,8 @@ class Environment:
         self.__module = module
         self.__modulepath = module._filepath
         self.__repopath = module.repository._filepath
-        self.__outpath = buildlog.outpath if buildlog else None
+        self.__outpath = buildlog.outpath if buildlog is not None else None
+        self.__cwdpath = buildlog.cwd if buildlog is not None else None
 
         self.buildlog = buildlog
         self.__template_environment = None
@@ -322,6 +323,20 @@ class Environment:
             return os.path.join(self.__outpath, *path)
 
         return os.path.join(self.__outpath, basepath, *path)
+
+    def cwdpath(self, *path):
+        """Relocate given path to current working directory"""
+        return os.path.join(self.__cwdpath, *path)
+
+    def cwdoutpath(self, *path):
+        """Relocate given path to the outpath in respect to current working directory"""
+        return self.outpath("", basepath="")
+
+    def relcwdoutpath(self, *path):
+        """Relocate given path to the outpath in respect to current working directory"""
+        relative = self.cwdpath("")
+        path = os.path.join(self.cwdoutpath(""), *path)
+        return os.path.relpath(os.path.abspath(path), os.path.abspath(relative))
 
     def reloutpath(self, path, relative=None):
         if relative is None:

--- a/lbuild/facade.py
+++ b/lbuild/facade.py
@@ -257,6 +257,15 @@ class EnvironmentValidateFacade:
     def localpath(self, *path):
         return self._env.modulepath(*path)
 
+    def cwdpath(self, *path):
+        return self._env.cwdpath(*path)
+
+    def cwdoutpath(self, *path):
+        return self._env.pcwdoutpath(*path)
+
+    def relcwdoutpath(self, *path):
+        return self._env.relcwdoutpath(*path)
+
     def __getitem__(self, key):
         return self._env.options[key]
 

--- a/lbuild/main.py
+++ b/lbuild/main.py
@@ -22,7 +22,7 @@ from lbuild.format import format_option_short_description
 
 from lbuild.api import Builder
 
-__version__ = '1.18.1'
+__version__ = '1.19.0'
 
 
 class InitAction:
@@ -316,7 +316,7 @@ class BuildAction(ManipulationActionBase):
 
     @staticmethod
     def perform(args, builder):
-        buildlog = builder.build(args.path, args.modules, simulate=args.simulate,
+        buildlog = builder.build(args.modules, simulate=args.simulate,
                                  use_symlinks=args.symlink)
 
         if args.simulate:
@@ -445,8 +445,8 @@ def prepare_argument_parser():
         '-p',
         '--path',
         dest='path',
-        default='.',
-        help="Path in which the library will be generated (default: '%(default)s').")
+        default=None,
+        help="Path in which the library will be generated (default: '.').")
     argument_parser.add_argument(
         '-D',
         '--option',
@@ -518,7 +518,7 @@ def run(args):
     except AttributeError:
         raise lbuild.exception.LbuildArgumentException("No command specified!")
 
-    builder = Builder(config=args.config, options=args.options, collectors=args.collectors)
+    builder = Builder(config=args.config, options=args.options, collectors=args.collectors, outpath=args.path)
     return command(args, builder)
 
 

--- a/lbuild/resources/configuration.xsd
+++ b/lbuild/resources/configuration.xsd
@@ -6,6 +6,7 @@
       <xsd:choice maxOccurs="unbounded">
         <xsd:element name="repositories" type="RepositoriesType" minOccurs="0" maxOccurs="1"/>
         <xsd:element name="extends" type="xsd:string" minOccurs="0" maxOccurs="unbounded"/>
+        <xsd:element name="outpath" type="xsd:string" minOccurs="0" maxOccurs="1"/>
         <xsd:element name="options" type="OptionsType" minOccurs="0" maxOccurs="1"/>
         <xsd:element name="modules" type="ModulesType" minOccurs="0" maxOccurs="1"/>
         <xsd:element name="collectors" type="CollectorsType" minOccurs="0" maxOccurs="1" />

--- a/test/api_test.py
+++ b/test/api_test.py
@@ -38,6 +38,7 @@ class ApiTest(unittest.TestCase):
             "repositories": list(),
             "vcs": list(),
             "cachefolder": ".lbuild_cache",
+            "outpath": None,
         }
         defaults.update(kw)
         for key, default in defaults.items():
@@ -51,11 +52,17 @@ class ApiTest(unittest.TestCase):
         api = lbuild.api.Builder(config="project.xml")
         self._assert_config(api)
 
+    def test_project_builder_outpath(self):
+        outputPath = "testpath"
+        api = lbuild.api.Builder(cwd=self._get_path("parser/api"), config="project.xml", outpath=outputPath)
+        self.assertEqual(api.outpath, outputPath)
+
     def test_config_builder(self):
         api = lbuild.api.Builder(config=self._get_path("parser/api/simple.xml"))
         self.assertEqual(api.cwd, self._get_path("parser/api"))
         self._assert_config(api,
             filename=self._rel_path("parser/api/simple.xml"),
+            outpath=self._get_path("parser/api/build/folder"),
             options={"repo:option": ("value", self._get_path("parser/api/simple.xml")),
                      "repo:module:option": ("value", self._get_path("parser/api/simple.xml"))},
             modules=["repo:module"],

--- a/test/config_test.py
+++ b/test/config_test.py
@@ -74,6 +74,7 @@ class ConfigTest(unittest.TestCase):
         config = self._parse_config("configfile/project.xml")
         del os.environ["LBUILD_TEST_REPOHOME"]
         self.assertEqual(self._get_path("configfile/hello_there"), abspath(config.cachefolder))
+        self.assertEqual(self._get_path("configfile/build/folder"), abspath(config.outpath))
 
         self.assertEqual(2, len(config.repositories))
         self.assertIn(self._get_path("repo2/repo2.lb"), config.repositories)
@@ -103,6 +104,7 @@ class ConfigTest(unittest.TestCase):
         self.assertEqual(config.collectors[1][1], 'value2')
         self.assertEqual(config.collectors[2][0], 'repo1:collect_empty')
         self.assertEqual(config.collectors[2][1], '')
+
 
     def test_should_parse_base_configuration(self):
         config = self._parse_config("configfile_inheritance/depth_0.xml")

--- a/test/resources/config/configfile/project.xml
+++ b/test/resources/config/configfile/project.xml
@@ -10,6 +10,8 @@
 		<cache>hello_there/</cache>
 	</repositories>
 
+	<outpath>build/folder</outpath>
+
 	<options>
 		<option name=":target">hosted</option>
 		<option name="repo1:foo">43</option>

--- a/test/resources/parser/api/simple.xml
+++ b/test/resources/parser/api/simple.xml
@@ -6,6 +6,8 @@
 		</repository>
 	</repositories>
 
+	<outpath>build/folder</outpath>
+
 	<options>
 		<option name="repo:option">value</option>
 		<option name="repo:module:option">value</option>


### PR DESCRIPTION

### related issue 
 * https://github.com/modm-io/lbuild/issues/65

### related PR
 * https://github.com/modm-io/modm/pull/645

### contents
 * added a lot of path specific options for environment
 * added lbuild:path xml option to overwrite given lbuild --path argument option
 * added project invocation path to environment, which can be looked up so get the path of the project (normally whererver lbuild was invoked)

