### PR TITLE
Add option transformation handler

### DIFF
--- a/README.md
+++ b/README.md
@@ -711,6 +711,7 @@ def add_option_dependencies(value):
 This is the most generic option, allowing to input any string.
 You may, however, provide your own validator that may raise a `ValueError`
 if the input string does not match your expectations.
+You may also pass a transformation function to convert the option value.
 The string is passed unmodified from the configuration to the module and the
 dependency handler.
 
@@ -719,10 +720,14 @@ def validate_string(string):
     if "please" not in string:
         raise ValueError("Input does not contain the magic word!")
 
+def transform_string(string):
+    return string.lower()
+
 option = StringOption(name="option-name",
                       description="inline", # or FileReader("file.md")
                       default="default string",
                       validate=validate_string,
+                      transform=transform_string,
                       dependencies=add_option_dependencies)
 ```
 
@@ -759,13 +764,20 @@ option = PathOption(name="option-name",
 
 #### BooleanOption
 
-This option maps strings from `true`, `yes`, `1` to `bool(True)` and `false`,
-`no`, `0` to `bool(False)`. The dependency handler is passed this `bool` value.
+This option maps strings from `true`, `yes`, `1`, `enable` to `bool(True)` and
+`false`, `no`, `0`, `disable` to `bool(False)`. You can extend this list with a
+custom transform handler. The dependency handler is passed this `bool` value.
 
 ```python
+def transform_boolean(string):
+    if string == 'y': return True;
+    if string == 'n': return False;
+    return string # hand over to built-in conversion
+
 option = BooleanOption(name="option-name",
                        description="boolean",
                        default=True,
+                       transform=transform_boolean,
                        dependencies=add_option_dependencies)
 ```
 

--- a/lbuild/main.py
+++ b/lbuild/main.py
@@ -22,7 +22,7 @@ from lbuild.format import format_option_short_description
 
 from lbuild.api import Builder
 
-__version__ = '1.17.0'
+__version__ = '1.18.0'
 
 
 class InitAction:

--- a/test/option_test.py
+++ b/test/option_test.py
@@ -98,6 +98,13 @@ class OptionTest(unittest.TestCase):
         option.value = False
         self.assertEqual("False", option.value)
 
+        option = StringOption("test", "description", default="hello",
+                              transform=lambda v: v.lower())
+        option.value = "HELLO"
+        self.assertEqual("hello", option.value)
+        option.value = False
+        self.assertEqual("false", option.value)
+
         def validate_string(value):
             if not isinstance(value, str):
                 raise TypeError("must be of type str")
@@ -178,7 +185,8 @@ class OptionTest(unittest.TestCase):
         self.assertEqual("/absolute/filename.txt", option.value)
 
     def test_should_be_constructable_from_boolean(self):
-        option = BooleanOption("test", "description", False)
+        option = BooleanOption("test", "description", False,
+                               transform=lambda v: True if v == "world" else v)
         self.assertIn("test  [BooleanOption]", option.description)
         self.assertEqual(False, option.value)
         option.value = 1
@@ -191,6 +199,8 @@ class OptionTest(unittest.TestCase):
         self.assertEqual(True, option.value)
         option.value = False
         self.assertEqual(False, option.value)
+        option.value = "world"
+        self.assertEqual(True, option.value)
 
         with self.assertRaises(le.LbuildOptionInputException):
             option.value = "hello"
@@ -378,10 +388,24 @@ class OptionTest(unittest.TestCase):
                       str(lbuild.format.format_option_value_description(option)))
 
     def test_should_format_boolean_option(self):
-        option = BooleanOption("test", "description", default=True)
+        option = BooleanOption("test", "description", default=True,
+                               transform=lambda v: True if v == "hello" else v)
 
         output = str(lbuild.format.format_option_value_description(option))
-        self.assertIn("True in [True, False]", output, "Output")
+        self.assertIn("yes in [yes, no]", output, "Output")
+
+        option.value = "hello"
+        self.assertEqual(True, option.value)
+        output = str(lbuild.format.format_option_value_description(option))
+        self.assertIn("hello in [yes, no]", output, "Output")
+
+        option.value = "1"
+        output = str(lbuild.format.format_option_value_description(option))
+        self.assertIn("1 in [yes, no]", output, "Output")
+
+        option.value = "TRUE"
+        output = str(lbuild.format.format_option_value_description(option))
+        self.assertIn("true in [yes, no]", output, "Output")
 
     def test_should_format_numeric_option(self):
 


### PR DESCRIPTION
Allows to make a StringOption input lower case for example.

Also changes the rendering of the BooleanOption to use yes/no instead of True/False, which makes lbuild discover a touch more human.