### PR TITLE
Print failure info even if code_context is None

### DIFF
--- a/lbuild/exception.py
+++ b/lbuild/exception.py
@@ -55,7 +55,7 @@ def _call_site(obj = None, plain = False):
     msg = "In file '{}:{}' in {} '{}':\n{}".format(
             _hl(_rel(filename), plain), _hl(lineno, plain),
             "class" if is_class else "function", _hl(name, plain),
-            code_context[0])
+            code_context and code_context[0])
     return msg
 
 

--- a/lbuild/main.py
+++ b/lbuild/main.py
@@ -22,7 +22,7 @@ from lbuild.format import format_option_short_description
 
 from lbuild.api import Builder
 
-__version__ = '1.18.0'
+__version__ = '1.18.1'
 
 
 class InitAction:


### PR DESCRIPTION
# Issue

I encountered a situation where code_context was None, which lead to a `TypeError: NoneType object is not subscriptable`  error, which was not at all helpful in tracking down the problem. This fix allows the original error information to be printed anyway in that case.

I admit I have not dug enough into this to know if it is reasonable that code_context might sometimes be None. Possibly this is a kluge, and there is a better fix. 

# Background

Some background in case anyone wants to dig further:

I encountered this while working on [modm PR 676](https://github.com/modm-io/modm/pull/676). The error came while running `python3 tools/scripts/docs_modm_io_generator.py -t -c -j4 -d` from the 'build-docs-test' CI job. Ultimately, it was because the LogicAnalyzer module in `test/modm/mock/module.lb` was depending on the `gpio_sampler` module, which was not available for the samg55 part I added. After applying the update in this PR, I got the error below, which was much more helpful than the NoneType message :).  

```
Error generating documentation for device samg55j19a-mu: Cannot resolve dependency ':driver:gpio_sampler' of Module(modm-test:mock:logic_analyzer)!
In file 'modm-samg/demo/ext/modm/test/modm/mock/module.lb:96' in function 'prepare':
    def prepare(self, module, options):
```

