### PR TITLE
Add configuration versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,8 +253,10 @@ which *lbuild* will search for in the current working directory.
   <!-- A repository may provide aliases for configurations, so that you can
        use a string as well, instead of a path. This saves you from knowing
        exactly where the configuration file is stored in the repo.
-       See also `repo.add_configuration(name, path)`. -->
+       See also `repo.add_configuration(...)`. -->
   <extends>repo:name_of_config</extends>
+  <!-- A configuration alias may also be versioned -->
+  <extends>repo:name_of_config:specific_version</extends>
   <!-- You can declare the *where* the output should be generated, default is cwd -->
   <outpath>generated/folder</outpath>
   <options>
@@ -318,6 +320,7 @@ global functions and classes for use in all files:
 - `{*}Query(...)`: classes for sharing code and data, [see Queries](#Queries).
 - `{*}Collector(...)`: classes for describing metadata sinks, [see Collectors](#Collectors).
 - `Alias(...)`: links to other nodes, [see Aliases](#Aliases).
+- `Configuration(...)`: links to a configuration inside the repository.
 
 
 ### Repositories
@@ -375,7 +378,14 @@ Use whatever markup you want, lbuild treats it all as text.
 
     # Add an alias for a internal configuration
     # NOTE: the configuration is namespaced with the repository! <extends>repo:config</extends>
-    repo.add_configuration("config", "internal/path/to/config.xml")
+    repo.add_configuration(Configuration(name="config",
+                                         description="Special Config",
+                                         path="path/to/config.xml")
+    # You can also add configuration versions
+    repo.add_configuration(Configuration(name="config2",
+                                         description="Versioned Config",
+                                         path={"v1": "path/to/config_v1.xml",
+                                               "v2": "path/to/config_v2.xml"})
 
     # See Options for more option types
     repo.add_option(StringOption(name="option", default="value"))

--- a/lbuild/exception.py
+++ b/lbuild/exception.py
@@ -165,7 +165,7 @@ class LbuildConfigAddNotFoundException(LbuildConfigException):
         message = (" not found!\n{}\n"
             "Hint: Check your config paths in '{}':\n\n"
             "   def init(repo):\n"
-            "       repo.add_configuration(name, \"{}\", description)"
+            "       repo.add_configuration(Configuration(name, description, \"{}\"))"
             .format(_call_site(repo._functions['init']),
                     _hl(_rel(repo._filename)), _hl(filename)))
         super().__init__(filename, message)
@@ -186,6 +186,17 @@ class LbuildConfigAliasAmbiguousException(LbuildConfigException):
                    .format(_hl(alias), aliases) + _dump(parser))
         filename = next( (f for f, a in parser._config_flat._extends.items() if alias in a), None)
         super().__init__(filename, message)
+
+class LbuildConfigNoDefaultException(LbuildConfigException):
+    def __init__(self, repo, config):
+        message = (" multiple paths must be defaulted!\n{}\n"
+            "Hint: Check your default value in '{}':\n\n"
+            "   def init(repo):\n"
+            "       repo.add_configuration(Configuration(name, description, paths, *default*))"
+            .format(_call_site(repo._functions['init']),
+                    _hl(_rel(repo._filename))))
+        super().__init__(repo.name + ":" + config.name, message)
+        self.node = repo
 
 
 # ============================= OPTION EXCEPTIONS =============================

--- a/lbuild/facade.py
+++ b/lbuild/facade.py
@@ -116,8 +116,13 @@ class RepositoryInitFacade(BaseNodeInitFacade):
     def add_filter(self, name, function):
         self._node._filters.append( (name, function,) )
 
-    def add_configuration(self, name, path, description=None):
-        self._node._configurations.append( (name, path, description,) )
+    def add_configuration(self, *config):
+        if len(config) > 1:
+            deprecated("1.21.0", "repo.add_configuraton(name, path, description)",
+                       "repo.add_configuraton(Configuration(name, description, path))")
+            config = [lbuild.repository.Configuration(
+                      name=config[0], path=config[1], description=config[2])]
+        self._node._configurations.append(config[0])
 
     def add_alias(self, alias):
         self._node._alias.append(alias)

--- a/lbuild/format.py
+++ b/lbuild/format.py
@@ -210,6 +210,10 @@ def format_description(node, description):
         value = format_option_value(node, single_line=False)[0]
         values = format_option_values(node, offset=9, single_line=False)
         output += [_cw(""), _cw("Value: ") + value, _cw("Inputs: [") + values + _cw("]")]
+    elif node.type == node.Type.CONFIG and node._enumeration.keys() != {""}:
+        value = format_option_value(node, single_line=False)[0]
+        values = format_option_values(node, offset=9, single_line=False)
+        output += [_cw(""), _cw("Version: ") + value, _cw("Versions: [") + values + _cw("]")]
     elif node.type == node.Type.COLLECTOR:
         values = format_option_values(node, offset=9, single_line=False)
         output += [_cw(""), _cw("Inputs: [") + values + _cw("]")]
@@ -243,11 +247,16 @@ def format_node(node, _, depth):
         name = _cw(node.name + " @ " + os.path.relpath(node._filepath))
     elif node._type == node.Type.OPTION:
         name = format_option_name(node, fullname=False)
-    elif node._type in {node.Type.MODULE, node.Type.CONFIG}:
+    elif node._type == node.Type.MODULE:
         name = _cw(node.fullname).wrap(node)
+    elif node._type == node.Type.CONFIG:
+        name = _cw(node.fullname)
+        if node._enumeration.keys() != {""}:
+            name += _cw(":") + _cw(node.value).wrap("bold")
+        name = _cw(name).wrap(node)
     elif node._type in {node.Type.QUERY, node.Type.COLLECTOR}:
         name = name.wrap("bold")
-    if node._type in {node.Type.MODULE} and node._selected:
+    if node._type in {node.Type.MODULE, node.Type.CONFIG} and node._selected:
         name = name.wrap("underlined")
 
     descr = (class_name + _cw("(") + name + _cw(")")).wrap(node)
@@ -256,6 +265,11 @@ def format_node(node, _, depth):
     if node._type == node.Type.OPTION:
         descr += _cw(" = ")
         descr += format_option_value_description(node, offset=offset + len(descr), single_line=True)
+    elif node._type == node.Type.CONFIG:
+        if len(node._enumeration) > 1:
+            descr += _cw(" in ")
+            values = format_option_values(node, offset + len(descr) + 5)
+            descr += _cw("[") + values + _cw("]")
     elif node._type == node.Type.COLLECTOR:
         descr += _cw(" in [")
         descr += format_option_values(node, offset=offset + len(descr), single_line=True)

--- a/lbuild/main.py
+++ b/lbuild/main.py
@@ -22,7 +22,7 @@ from lbuild.format import format_option_short_description
 
 from lbuild.api import Builder
 
-__version__ = '1.20.0'
+__version__ = '1.21.0'
 
 
 class InitAction:

--- a/lbuild/parser.py
+++ b/lbuild/parser.py
@@ -111,13 +111,18 @@ class Parser(BaseNode):
             for filename, aliases in self._config_flat._extends.items():
                 node = self._config.find(filename)
                 for alias in aliases:
+                    version = None
+                    if alias.count(":") > 1:
+                        alias, version = alias.rsplit(":", 1)
                     try:
                         fconfig = self.config_resolver[alias]
+                        fconfig._selected = True
+                        if version: fconfig.value = version
                     except le.LbuildResolverNoMatchException:
                         raise le.LbuildConfigAliasNotFoundException(self, alias)
                     except le.LbuildResolverAmbiguousMatchException as e:
                         raise le.LbuildConfigAliasAmbiguousException(self, alias, e.results)
-                    self._config.extend(node, ConfigNode.from_file(fconfig._config))
+                    self._config.extend(node, ConfigNode.from_file(fconfig._enumeration[fconfig.value]))
                 node._extends.pop(filename)
 
         self._update_format()

--- a/test/config_test.py
+++ b/test/config_test.py
@@ -190,5 +190,27 @@ class ConfigTest(unittest.TestCase):
         self.assertIn("::submodule3:subsubmodule1", config.modules)
         self.assertIn("::submodule3", config.modules)
 
+    def test_should_build_versions(self):
+        config = lbuild.repository.Configuration("test", "", "hello.xml")
+        self.assertEqual(1, len(config._enumeration))
+        self.assertEqual("", config.value)
+        self.assertEqual("hello.xml", config._enumeration[config.value])
+        self.assertIn("Config(test)", lbuild.format.format_node(config, None, 0))
+
+        config = lbuild.repository.Configuration("test", "", {"v1": "version1.xml"})
+
+
+        config = lbuild.repository.Configuration("test", "", {"v1": "version1.xml"}, "v1")
+        self.assertEqual(1, len(config._enumeration))
+        self.assertEqual("v1", config.value)
+        self.assertEqual("version1.xml", config._enumeration[config.value])
+        self.assertIn("Config(test:v1)", lbuild.format.format_node(config, None, 0))
+
+        config = lbuild.repository.Configuration("test", "", {"v1": "version1.xml", "v2": "version2.xml"}, "v2")
+        self.assertEqual(2, len(config._enumeration))
+        self.assertEqual("v2", config.value)
+        self.assertEqual("version2.xml", config._enumeration[config.value])
+        self.assertIn("Config(test:v2) in [v1, v2]", lbuild.format.format_node(config, None, 0))
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This adds the ability to add an enumeration of version strings mapped to config files, effectively creating a group of configs with a default config.
This allows you to use completely different configuration files incl. different module selection and module options for a subversion of the config.
In addition, the config version can be queried through the options interface as a repo option.

The config is extended by the version as a subconfig: `<extends>modm:disco-f469ni:b03</extends>` selects the b03 config. `<extends>modm:disco-f469ni</extends>` defaults to `b01` (can be customized though).

The versions are discoverable in the tree view:
```
 $ lbuild discover
Parser(lbuild)
╰── Repository(modm @ ../../..)   modm: a barebone embedded library generator
    ├── Option(target) = stm32f469nih6 in [...]
    ├── Config(modm:disco-f407vg)   STM32F4DISCOVERY
    ├── Config(modm:disco-f429zi)   STM32F429IDISCOVERY
    ├── Config(modm:disco-f469ni:b03) in [b01, b02, b03]   STM32F469IDISCOVERY
    ├── Config(modm:disco-f746ng)   STM32F7DISCOVERY
    ├── Config(modm:disco-f769ni)   STM32F769IDISCOVERY
```

And also in the detail view:
```
 $ lbuild discover :disco-f469ni
>> modm:disco-f469ni  [Configuration]

# STM32F469IDISCOVERY

Discovery kit with STM32F469NI MCU.

Version: b03
Versions: [b01, b02, b03]
```

TODO: 
- [x] Unit tests
- [x] More detailed documentation
- [x] Bump version

cc @rleh