### PR TITLE
Fix input dependencies for boolean option

### DIFF
--- a/lbuild/main.py
+++ b/lbuild/main.py
@@ -22,7 +22,7 @@ from lbuild.format import format_option_short_description
 
 from lbuild.api import Builder
 
-__version__ = '1.21.4'
+__version__ = '1.21.5'
 
 
 class InitAction:

--- a/lbuild/option.py
+++ b/lbuild/option.py
@@ -177,6 +177,8 @@ class BooleanOption(Option):
         Option.__init__(self, name, description, default, dependencies, transform=transform,
                         convert_input=self.input_boolean,
                         convert_output=self.output_boolean)
+        if self._dependency_handler:
+            self._dependency_handler = lambda _input: dependencies(self.output_boolean(_input))
 
     @property
     def values(self):


### PR DESCRIPTION
It's not very useful if the input of the boolean option is not converted to a boolean first.
The string is not very helpful…