### PR TITLE
Take the absolute config path to search for parent configs

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.5, 3.6, 3.7, 3.8, 3.9]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
 
     steps:
       - uses: actions/checkout@v2

--- a/lbuild/config.py
+++ b/lbuild/config.py
@@ -149,7 +149,7 @@ class ConfigNode(anytree.AnyNode):
             otherwise.
         """
         configs = []
-        startpath = Path(startpath) if startpath else Path.cwd()
+        startpath = Path(os.path.abspath(startpath)) if startpath else Path.cwd()
         while startpath.exists():
             config = (startpath / name)
             if config.exists():

--- a/lbuild/main.py
+++ b/lbuild/main.py
@@ -22,7 +22,7 @@ from lbuild.format import format_option_short_description
 
 from lbuild.api import Builder
 
-__version__ = '1.21.6'
+__version__ = '1.21.7'
 
 
 class InitAction:


### PR DESCRIPTION
If it comes from a cli argument it might be a relative path and it fails (with a couple of prints around that place):

```bash
$ lbuild -p generated/unittest/nucleo-f446re -c config/nucleo-f446re.xml  -C generated/unittest/nucleo-f446re build
config
config
config
.

ERROR: Configuration(config/nucleo-f446re.xml): name 'modm:nucleo-f446re' not found in any repository!
....
```

Afterwards, obviously it prints the absolute paths up to `/`

I did not look into what else changed, since that project worked well a long time (ago),  
and those lines around were not changed in a longer time as well, ... :shrug: 