### PR TITLE
Fix alias unresolvable warning

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
 
     steps:
       - uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # lbuild: generic, modular code generation in Python 3
 
-The Library Builder (pronounced *lbuild*) is a BSD licensed [Python 3.5 tool][python]
+The Library Builder (pronounced *lbuild*) is a BSD licensed [Python 3 tool][python]
 for describing repositories containing modules which can copy or generate a set
 of files based on the user provided data and options.
 

--- a/lbuild/main.py
+++ b/lbuild/main.py
@@ -22,7 +22,7 @@ from lbuild.format import format_option_short_description
 
 from lbuild.api import Builder
 
-__version__ = '1.21.7'
+__version__ = '1.21.8'
 
 
 class InitAction:

--- a/lbuild/node.py
+++ b/lbuild/node.py
@@ -134,7 +134,7 @@ class NameResolver:
             try:
                 node = context_resolver._get_node(node._destination)
                 warning += node.description + "\n"
-            except LbuildException as e:
+            except le.LbuildException as e:
                 LOGGER.warning(warning)
                 raise e
             if alias._print_warning:

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ with open("README.md") as f:
 setup(
     name = "lbuild",
     version = __version__,
-    python_requires=">=3.5.0",
+    python_requires=">=3.8.0",
     entry_points={
         "console_scripts": [
             "lbuild = lbuild.main:main",
@@ -58,7 +58,6 @@ setup(
         "Operating System :: OS Independent",
         "Programming Language :: Python",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.5",
         "Topic :: Software Development",
         "Topic :: Software Development :: Code Generators",
         "Topic :: Software Development :: Embedded Systems",


### PR DESCRIPTION
When an alias is not resolvable it should print a useful warning, not throw an unhandled exception.

Also makes the minimum version Python 3.8 (3.5 is really old and EOL).